### PR TITLE
Modifying the footer controls block interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,18 @@ ember install ember-frost-modal
 | --------- | ---- | ----- | ----------- |
 | `modalName` | `string` | <name> | Optional name for the modal |
 | `modalClass` | `string` | <class-name> | Optional class to add custom styles to the modal |
-| `confirm` | `Function` | <action-name> | Optional callback triggered if confirm button is used |
-| `onOpen` | `Function` | <action-name> | Optional callback triggered after the modal opens |
-| `onClose` | `Function` | <action-name> | Optional callback triggered after the modal closes |
 
 ## Slots API
-Using [ember-block-slots](https://github.com/ciena-blueplanet/ember-block-slots), this generic modal dialog can be wrapped inside other more complex modal components. This basic modal will provide a header, scrollable content area and footer with actions. The required slots are `target` and `cancel`, to provide a way to launch and close the modal dialog respectively.
+Using [ember-block-slots](https://github.com/ciena-blueplanet/ember-block-slots), this generic modal dialog can be wrapped inside other more complex modal components. This basic modal will provide a header, scrollable content area and footer with actions. The required slots are `target` and `footer`, to provide a way to launch and close the modal dialog respectively.
+
+### Footer controls block
+The `footer` block can yield a `cancel`, `confirm` or generic button type. The `cancel` button is internally hooked up to close the dialog. The `confirm` button is a primary button that takes a `onConfirm` action handler to allow the consumer to perform actions on confirmation, eg saving a record, and it automatically closes the dialog. If you require another custom button, you can use the generic button type. To set an action handler on that button, set the attr `onActionClick`. All button text, size and priority can be overridden.
 
 ## Examples
 ```handlebars
+frost-modal testbed
 {{#frost-modal
-  confirm=(action 'confirmHandler') as |slot|}}
+  modalName='testModal' as |slot|}}
   {{#block-slot slot 'target'}}
     {{frost-button
       priority="primary"
@@ -45,29 +46,26 @@ Using [ember-block-slots](https://github.com/ciena-blueplanet/ember-block-slots)
     }}
   {{/block-slot}}
   {{#block-slot slot 'header'}}
-    <div class="primary-title">Test title</div>
+    <div class="primary-title">TEST TITLE</div>
   {{/block-slot}}
   {{#block-slot slot 'body'}}
     <div class="custom-body">
       <div>Test Information block</div>
+      <div>Test Information block</div>
     </div>
   {{/block-slot}}
-  {{#block-slot slot 'cancel'}}
-    {{frost-button
-      autofocus=true
-      size='medium'
-      priority='tertiary'
-      text='Cancel'
-    }}
-  {{/block-slot}}
-  {{#block-slot slot 'confirm'}}
-    {{frost-button
-      size='medium'
-      priority='primary'
-      text='Confirm'
-    }}
+  {{#block-slot slot 'footer' as |controls|}}
+    {{controls.cancel
+      text='Cancel'}}
+    {{controls.button
+      text='Custom action'
+      onActionClick=(action 'myCustomAction')}}
+    {{controls.confirm
+      onConfirm=(action 'confirmHandler')
+      text='Confirm'}}
   {{/block-slot}}
 {{/frost-modal}}
+
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -27,11 +27,27 @@ ember install ember-frost-modal
 | `modalName` | `string` | <name> | Optional name for the modal |
 | `modalClass` | `string` | <class-name> | Optional class to add custom styles to the modal |
 
-## Slots API
+### Ember-remodal
+
+This addon uses the [ember-remodal](http://sethbrasile.github.io/ember-remodal/) service as a base for the modal behavior.
+
+### Slots API
+
 Using [ember-block-slots](https://github.com/ciena-blueplanet/ember-block-slots), this generic modal dialog can be wrapped inside other more complex modal components. This basic modal will provide a header, scrollable content area and footer with actions. The required slots are `target` and `footer`, to provide a way to launch and close the modal dialog respectively.
 
 ### Footer controls block
-The `footer` block can yield a `cancel`, `confirm` or generic button type. The `cancel` button is internally hooked up to close the dialog. The `confirm` button is a primary button that takes a `onConfirm` action handler to allow the consumer to perform actions on confirmation, eg saving a record, and it automatically closes the dialog. If you require another custom button, you can use the generic button type. To set an action handler on that button, set the attr `onActionClick`. All button text, size and priority can be overridden.
+
+The `footer` block can yield a `cancel`, `confirm` or generic button type. The `cancel` button is internally hooked up to close the dialog.
+The button text can be customized using the `text` attribute. The `cancel` button text defaults to `Cancel`. The `confirm` button text defaults to `Confirm`.
+The `confirm` button is a primary button that takes a `onConfirm` action handler to allow the consumer to perform actions on confirmation, eg saving a record, and it automatically closes the dialog.
+If you require another custom button, you can use the generic button type. To set an action handler on that button, set the attr `onActionClick`. All button text, size and priority can be overridden.
+
+### ember-perfectscroll effects
+
+This gives you styling of header/footer when content is scrolled underneath either element
+
+Styling includes: box shadow plus slight transparency in header/footer to reveal content underneath
+For more documentation on ember-perfectscroll:  [perfect-scrollbar](https://github.com/noraesae/perfect-scrollbar)
 
 ## Examples
 ```handlebars
@@ -55,14 +71,13 @@ frost-modal testbed
     </div>
   {{/block-slot}}
   {{#block-slot slot 'footer' as |controls|}}
-    {{controls.cancel
-      text='Cancel'}}
+    {{controls.cancel}}
     {{controls.button
       text='Custom action'
-      onActionClick=(action 'myCustomAction')}}
+      onClick=(action 'myCustomAction')}}
     {{controls.confirm
       onConfirm=(action 'confirmHandler')
-      text='Confirm'}}
+      text='Confirm it!'}}
   {{/block-slot}}
 {{/frost-modal}}
 

--- a/addon/components/action-button.js
+++ b/addon/components/action-button.js
@@ -1,0 +1,26 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  init () {
+    this._super(...arguments)
+    if (this.get('type') === 'close') {
+      // this.set('onActionClick', modalClose))
+    } else if (this.get('type') === 'confirm') {
+      const confirm = this.get('confirm')
+      if (confirm) {
+        this.set('onActionClick', confirm)
+        // send modal close?
+      }
+    }
+  },
+  actions: {
+    onActionClick () {
+       const onActionClick = this.get('onActionClick')
+       console.log('HERE')
+       if (onActionClick) {
+         onActionClick()
+       }
+     }
+  }
+
+})

--- a/addon/components/action-button.js
+++ b/addon/components/action-button.js
@@ -1,26 +1,17 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-  init () {
-    this._super(...arguments)
-    if (this.get('type') === 'close') {
-      // this.set('onActionClick', modalClose))
-    } else if (this.get('type') === 'confirm') {
-      const confirm = this.get('confirm')
-      if (confirm) {
-        this.set('onActionClick', confirm)
-        // send modal close?
-      }
-    }
-  },
+
   actions: {
     onActionClick () {
-       const onActionClick = this.get('onActionClick')
-       console.log('HERE')
-       if (onActionClick) {
-         onActionClick()
-       }
-     }
+      if (this.get('type') === 'confirm') {
+        const confirm = this.get('confirm')
+        if (confirm) {
+          confirm()
+        }
+      }
+      this.attrs['onClose']()
+    }
   }
 
 })

--- a/addon/components/action-button.js
+++ b/addon/components/action-button.js
@@ -1,22 +1,38 @@
 import Ember from 'ember'
+import FrostButton from 'ember-frost-core/components/frost-button'
+const { ViewUtils } = Ember
 
-export default Ember.Component.extend({
+/**
+ * @module
+ * @augments module:ember-frost-core/components/frost-button
+ */
+export default FrostButton.extend({
 
-  actions: {
-    onActionClick () {
-      if (this.get('type') === 'confirm') {
-        if (this.attrs['onConfirm']) {
-          this.attrs['onConfirm']()
-          this.attrs['onClose']()
-        }
-      }
-      if (this.get('type') === 'cancel') {
+  /**
+   * Sets up behavior for onClick event
+   *
+   * @function
+   * @param  {Object} event The mouse click event
+   * @return {Boolean} If user does Shift|Ctrl|Alt|Meta|Secondary + click, then exit the function
+   * without doing the logic to execute the closure action
+   */
+  onclick: Ember.on('click', function (event) {
+    if (!ViewUtils.isSimpleClick(event)) {
+      return true
+    }
+
+    if (this.get('type') === 'confirm') {
+      if (this.attrs['onConfirm']) {
+        this.attrs['onConfirm']()
         this.attrs['onClose']()
       }
-      const customAction = this.get('onActionClick')
-      if (customAction) {
-        customAction()
-      }
     }
-  }
+    if (this.get('type') === 'cancel') {
+      this.attrs['onClose']()
+    }
+    const customAction = this.get('onClick')
+    if (customAction) {
+      customAction()
+    }
+  })
 })

--- a/addon/components/action-button.js
+++ b/addon/components/action-button.js
@@ -1,17 +1,22 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Component.extend({
 
   actions: {
     onActionClick () {
       if (this.get('type') === 'confirm') {
-        const confirm = this.get('confirm')
-        if (confirm) {
-          confirm()
+        if (this.attrs['onConfirm']) {
+          this.attrs['onConfirm']()
+          this.attrs['onClose']()
         }
       }
-      this.attrs['onClose']()
+      if (this.get('type') === 'cancel') {
+        this.attrs['onClose']()
+      }
+      const customAction = this.get('onActionClick')
+      if (customAction) {
+        customAction()
+      }
     }
   }
-
 })

--- a/addon/components/frost-modal.js
+++ b/addon/components/frost-modal.js
@@ -135,7 +135,6 @@ export default Component.extend(PropTypeMixin, {
   actions: {
     confirm () {
       const confirm = this.get('confirm')
-
       if (confirm) {
         confirm()
       }
@@ -151,15 +150,13 @@ export default Component.extend(PropTypeMixin, {
       if (!this.get('scrollBindingsSet')) {
         this.setScrollBindings()
       }
-      const onOpen = this.get('onOpen')
 
+      const onOpen = this.get('onOpen')
       if (onOpen) {
         onOpen()
       }
     },
-    modalClose (confirmHandler) {
-      confirmHandler()
-      console.log(IN HERE);
+    modalClose () {
       Ember.$(document).off('ps-scroll-up ps-scroll-down ps-y-reach-start ps-y-reach-end')
 
       Ember.$(window).off('resize', this.updateScrollStyles)
@@ -168,6 +165,9 @@ export default Component.extend(PropTypeMixin, {
         this.get('containerObserver').disconnect()
       }
       this.set('scrollBindingsSet', false)
+
+      this.get('remodal').close(this.get('computedName'))
+
       const onClose = this.get('onClose')
 
       if (onClose) {

--- a/addon/components/frost-modal.js
+++ b/addon/components/frost-modal.js
@@ -173,12 +173,6 @@ export default Component.extend(PropTypeMixin, {
       if (onClose) {
         onClose()
       }
-      // const name = this.get('computedName')
-      // const remodalInstance = name !== '' ? `remodal.${name}` : 'remodal.ember-remodal'
-      // const modalInstance = `${remodalInstance}.modal`
-      // this.get(remodalInstance)._destroyDomElements()
-      // this.get(remodalInstance)._deregisterObservers()
-      // this.set(modalInstance, null)
     }
   }
 })

--- a/addon/components/frost-modal.js
+++ b/addon/components/frost-modal.js
@@ -6,6 +6,7 @@ import PropTypeMixin from 'ember-prop-types'
 import _ from 'lodash/lodash'
 
 export default Component.extend(PropTypeMixin, {
+  remodal: Ember.inject.service(),
   // ==========================================================================
   // Dependencies
   // ==========================================================================
@@ -156,7 +157,9 @@ export default Component.extend(PropTypeMixin, {
         onOpen()
       }
     },
-    modalClose () {
+    modalClose (confirmHandler) {
+      confirmHandler()
+      console.log(IN HERE);
       Ember.$(document).off('ps-scroll-up ps-scroll-down ps-y-reach-start ps-y-reach-end')
 
       Ember.$(window).off('resize', this.updateScrollStyles)
@@ -170,6 +173,12 @@ export default Component.extend(PropTypeMixin, {
       if (onClose) {
         onClose()
       }
+      // const name = this.get('computedName')
+      // const remodalInstance = name !== '' ? `remodal.${name}` : 'remodal.ember-remodal'
+      // const modalInstance = `${remodalInstance}.modal`
+      // this.get(remodalInstance)._destroyDomElements()
+      // this.get(remodalInstance)._deregisterObservers()
+      // this.set(modalInstance, null)
     }
   }
 })

--- a/app/components/action-button.js
+++ b/app/components/action-button.js
@@ -1,0 +1,1 @@
+export {default} from 'ember-frost-modal/components/action-button'

--- a/app/templates/components/action-button.hbs
+++ b/app/templates/components/action-button.hbs
@@ -1,7 +1,0 @@
-{{frost-button
-  disabled=isDisabled
-  onClick=(action 'onActionClick')
-  priority=priority
-  size=size
-  text=text
-}}

--- a/app/templates/components/action-button.hbs
+++ b/app/templates/components/action-button.hbs
@@ -1,0 +1,7 @@
+{{frost-button
+  disabled=isDisabled
+  onClick=(action 'onActionClick')
+  priority=priority
+  size=size
+  text=text
+}}

--- a/app/templates/components/frost-modal.hbs
+++ b/app/templates/components/frost-modal.hbs
@@ -32,16 +32,23 @@
   {{/perfect-scroll}}
 
   <div class='footer'>
-    {{#modal.cancel}}
-      {{#yield-slot 'cancel'}}
-        {{yield}}
-      {{/yield-slot}}
-    {{/modal.cancel}}
-
-    {{#modal.confirm}}
+    {{#yield-slot 'footer'}}
+    {{!-- {{#modal.cancel}} --}}
+    {{yield (block-params
+      (hash
+        button=(component
+        'action-button'
+          priority='tertiary'
+          size='medium'
+        )
+      )
+    )}}
+    {{!-- {{/modal.cancel}} --}}
+    {{!-- {{#modal.confirm}}
       {{#yield-slot 'confirm'}}
         {{yield}}
       {{/yield-slot}}
-    {{/modal.confirm}}
+    {{/modal.confirm}} --}}
+    {{/yield-slot}}
   </div>
 {{/ember-remodal}}

--- a/app/templates/components/frost-modal.hbs
+++ b/app/templates/components/frost-modal.hbs
@@ -4,8 +4,6 @@
   modalClasses=computedClasses
   name=computedName
   onOpen=(action 'modalOpen')
-  onClose=(action 'modalClose')
-  onConfirm=(action 'confirm')
   closeOnEscape=false
   disableNativeClose=true as |modal|
 }}
@@ -33,22 +31,15 @@
 
   <div class='footer'>
     {{#yield-slot 'footer'}}
-    {{!-- {{#modal.cancel}} --}}
     {{yield (block-params
       (hash
         button=(component
         'action-button'
           priority='tertiary'
           size='medium'
-        )
-      )
+          onClose=(action 'modalClose')
+        ))
     )}}
-    {{!-- {{/modal.cancel}} --}}
-    {{!-- {{#modal.confirm}}
-      {{#yield-slot 'confirm'}}
-        {{yield}}
-      {{/yield-slot}}
-    {{/modal.confirm}} --}}
     {{/yield-slot}}
   </div>
 {{/ember-remodal}}

--- a/app/templates/components/frost-modal.hbs
+++ b/app/templates/components/frost-modal.hbs
@@ -33,12 +33,26 @@
     {{#yield-slot 'footer'}}
     {{yield (block-params
       (hash
-        button=(component
+        cancel=(component
         'action-button'
+          type='cancel'
           priority='tertiary'
           size='medium'
           onClose=(action 'modalClose')
-        ))
+        )
+        confirm=(component
+          'action-button'
+          type='confirm'
+          priority='primary'
+          size='medium'
+          onClose=(action 'modalClose')
+          )
+        button=(component
+          'action-button'
+          size='medium'
+          priority='secondary'
+          )
+        )
     )}}
     {{/yield-slot}}
   </div>

--- a/app/templates/components/frost-modal.hbs
+++ b/app/templates/components/frost-modal.hbs
@@ -35,6 +35,7 @@
       (hash
         cancel=(component
         'action-button'
+          text='Cancel'
           type='cancel'
           priority='tertiary'
           size='medium'
@@ -42,6 +43,7 @@
         )
         confirm=(component
           'action-button'
+          text='Confirm'
           type='confirm'
           priority='primary'
           size='medium'

--- a/tests/dummy/app/pods/demo/controller.js
+++ b/tests/dummy/app/pods/demo/controller.js
@@ -9,6 +9,9 @@ export default Ember.Controller.extend({
         autoClear: true,
         clearDuration: 2000
       })
+    },
+    myCustomAction: function () {
+      console.log('My Custom action triggered')
     }
   }
 })

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -1,6 +1,6 @@
 frost-modal testbed
 {{#frost-modal
-  confirm=(action 'confirmHandler') as |slot|}}
+  modalName='testModal' as |slot|}}
   {{#block-slot slot 'target'}}
     {{frost-button
       priority="primary"
@@ -9,7 +9,7 @@ frost-modal testbed
     }}
   {{/block-slot}}
   {{#block-slot slot 'header'}}
-    <div class="primary-title">Test title</div>
+    <div class="primary-title">BLAH</div>
   {{/block-slot}}
   {{#block-slot slot 'body'}}
     <div class="custom-body">
@@ -40,19 +40,13 @@ frost-modal testbed
       <div>Test Information block</div>
     </div>
   {{/block-slot}}
-  {{#block-slot slot 'cancel'}}
-    {{frost-button
-      autofocus=true
-      size='medium'
-      priority='tertiary'
-      text='Cancel'
-    }}
-  {{/block-slot}}
-  {{#block-slot slot 'confirm'}}
-    {{frost-button
-      size='medium'
-      priority='primary'
-      text='Confirm'
-    }}
+  {{#block-slot slot 'footer' as |actions|}}
+    {{actions.button
+      type='close'
+      text='Cancel'}}
+    {{actions.button
+      confirm=(action 'confirmHandler')
+      type='confirm'
+      text='Confirm'}}
   {{/block-slot}}
 {{/frost-modal}}

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -40,14 +40,14 @@ frost-modal testbed
       <div>Test Information block</div>
     </div>
   {{/block-slot}}
-  {{#block-slot slot 'footer' as |actions|}}
-    {{actions.button
-      type='close'
+  {{#block-slot slot 'footer' as |controls|}}
+    {{controls.cancel
       text='Cancel'}}
-    {{actions.button
-      confirm=(action 'confirmHandler')
-      priority='primary'
-      type='confirm'
+    {{controls.button
+      text='Custom action'
+      onActionClick=(action 'myCustomAction')}}
+    {{controls.confirm
+      onConfirm=(action 'confirmHandler')
       text='Confirm'}}
   {{/block-slot}}
 {{/frost-modal}}

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -41,13 +41,12 @@ frost-modal testbed
     </div>
   {{/block-slot}}
   {{#block-slot slot 'footer' as |controls|}}
-    {{controls.cancel
-      text='Cancel'}}
+    {{controls.cancel}}
     {{controls.button
       text='Custom action'
-      onActionClick=(action 'myCustomAction')}}
+      onClick=(action 'myCustomAction')}}
     {{controls.confirm
       onConfirm=(action 'confirmHandler')
-      text='Confirm'}}
+      text='Confirm it!'}}
   {{/block-slot}}
 {{/frost-modal}}

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -46,6 +46,7 @@ frost-modal testbed
       text='Cancel'}}
     {{actions.button
       confirm=(action 'confirmHandler')
+      priority='primary'
       type='confirm'
       text='Confirm'}}
   {{/block-slot}}


### PR DESCRIPTION
# major
# Changelog
## Breaking
- Changed the footer block controls interface to more cleanly support cancel, confirm and custom buttons within a single block-slot
