### PR TITLE
Clean up nested selectors & add github templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Frost Contribution Guidelines
+Like all great open-source software, Frost welcomes contributions from the community.
+In order to maintain consistency, we ask contributors to follow the following guidelines.
+
+## CLA
+Coming Soon
+
+## Pull Requests
+We use [`pr-bumper`](github.com/ciena-blueplanet/pr-bumper) in our projects, so every pull request should include a
+comment about what kind of change is being provided (think [`semver`](semver.org)). The [`README`](github.com/ciena-blueplanet/pr-bumper/blob/master/README.md#pull-requests) from `pr-bumper` has more details,
+but the gist of it is you need to include a directive in your pull request description that tells `pr-bumper` whether
+the change is `#major#`, `#minor#`, or `#patch#`.
+
+It is also encouraged (soon to be required) to include a `# CHANGELOG` section in the pull request description.
+Everything underneath this section will be prepended to the `CHANGELOG.md` in the repository when the pull-request
+is merged under a section with the new version number that was created as a result of the merged pull request.
+
+## Linting
+We lint all the things.
+
+### `.js` files
+We use an extension of [`standard`](standardjs.com), so if your editor can run `eslint`, you should be all set.
+
+### `.scss` files
+We use `sass-lint` with nearly default rules (except `smacss` property order)
+
+### `.hbs` files
+We use `ember-cli-template-lint`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+### This project uses [semver](semver.org), please check the scope of this pr:
+ - [ ] #patch# - backwards-compatible bug fix
+ - [ ] #minor# - adding functionality in a backwards-compatible manner
+ - [ ] #major# - incompatible API change
+
+# CHANGELOG
+Please add a description of your change here, it will be automatically prepended to the `CHANGELOG.md` file.

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -236,7 +236,7 @@ rules:
 
   # enforce how deeply a selector can be nested (defaults to 2)
   # https://github.com/sasstools/sass-lint/blob/master/docs/rules/nesting-depth.md
-  nesting-depth: 0
+  nesting-depth: 2
 
   # enforce the order in which declarations are written (default alphabetical)
   # https://github.com/sasstools/sass-lint/blob/master/docs/rules/property-sort-order.md

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -8,6 +8,70 @@ $action-bar-border-width: 1px;
 $action-bar-height: 80px;
 $scroll-box-shadow: rgba(0, 0, 0, .25);
 
+@mixin frost-modal-header-builtins {
+  display: flex;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  height: $info-bar-height + $info-bar-border-width;
+  padding: $info-bar-padding-top-bottom $info-bar-padding-left-right;
+  border-bottom: $info-bar-border-width solid $frost-color-lgrey-1;
+  z-index: 999;
+
+  &.header-scrolled {
+    border-bottom: 0;
+    box-shadow: 0 2px 3px $scroll-box-shadow;
+
+    &:after {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      height: $info-bar-height + $info-bar-border-width;
+      background: $frost-color-white;
+      content: '';
+      z-index: -1;
+    }
+  }
+}
+
+@mixin frost-modal-footer-builtins {
+  display: flex;
+  position: absolute;
+  bottom: 0;
+  align-items: center;
+  justify-content: flex-end;
+  width: 100%;
+  height: $action-bar-height + $action-bar-border-width;
+  margin-top: 20px;
+  padding-right: 30px;
+  border-top: 1px solid $frost-color-lgrey-1;
+  z-index: 999;
+
+  &:after {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    height: $action-bar-height + $action-bar-border-width;
+    background: $frost-color-white;
+    content: '';
+    opacity: .95;
+    z-index: -1;
+  }
+
+  .frost-button {
+    min-width: 120px;
+    margin-left: 10px;
+  }
+
+  &.footer-scrolled {
+    box-shadow: 0 -2px 3px $scroll-box-shadow;
+  }
+}
+
 .frost-modal {
   &.ember-remodal {
     &.window {
@@ -17,90 +81,32 @@ $scroll-box-shadow: rgba(0, 0, 0, .25);
       max-height: calc(100vh - 90px);
       padding: 0;
       overflow: hidden;
+    }
+  }
 
-      .ember-remodal {
-        &.yielded {
-          &.content {
-            display: flex;
-            flex-direction: column;
+  .ember-remodal {
+    &.yielded {
+      display: flex;
+      flex-direction: column;
 
-            .header {
-              display: flex;
-              position: absolute;
-              top: 0;
-              width: 100%;
-              height: $info-bar-height + $info-bar-border-width;
-              padding: $info-bar-padding-top-bottom $info-bar-padding-left-right;
-              border-bottom: $info-bar-border-width solid $frost-color-lgrey-1;
-              z-index: 999;
+      .header {
+        @include frost-modal-header-builtins;
+      }
 
-              &.header-scrolled {
-                border-bottom: 0;
-                box-shadow: 0 2px 3px $scroll-box-shadow;
+      .ps-container {
+        position: relative;
+        max-height: calc(100vh - 90px);
+        padding: 0;
+        overflow: auto;
 
-                &:after {
-                  position: absolute;
-                  top: 0;
-                  right: 0;
-                  bottom: 0;
-                  left: 0;
-                  height: $info-bar-height + $info-bar-border-width;
-                  background: $frost-color-white;
-                  content: '';
-                  z-index: -1;
-                }
-              }
-            }
-
-            .ps-container {
-              position: relative;
-              max-height: calc(100vh - 90px);
-              padding: 0;
-              overflow: auto;
-
-              .ps-scrollbar-y-rail {
-                margin-top: $info-bar-height + $info-bar-border-width;
-                margin-bottom: $action-bar-height + $info-bar-border-width;
-              }
-            }
-
-            .footer {
-              display: flex;
-              position: absolute;
-              bottom: 0;
-              align-items: center;
-              justify-content: flex-end;
-              width: 100%;
-              height: $action-bar-height + $action-bar-border-width;
-              margin-top: 20px;
-              padding-right: 30px;
-              border-top: 1px solid $frost-color-lgrey-1;
-              z-index: 999;
-
-              &:after {
-                position: absolute;
-                top: 0;
-                right: 0;
-                bottom: 0;
-                left: 0;
-                height: $action-bar-height + $action-bar-border-width;
-                background: $frost-color-white;
-                content: '';
-                opacity: .95;
-                z-index: -1;
-              }
-
-              .frost-button {
-                min-width: 120px;
-                margin-left: 20px;
-              }
-
-              &.footer-scrolled {
-                box-shadow: 0 -2px 3px $scroll-box-shadow;
-              }
-            }
-          }
+        .ps-scrollbar-y-rail {
+          margin-top: $info-bar-height + $info-bar-border-width;
+          margin-bottom: $action-bar-height + $info-bar-border-width;
         }
+      }
+
+      .footer {
+        @include frost-modal-footer-builtins;
       }
     }
   }


### PR DESCRIPTION
This #patch# just refactored some of the `sass` in `addon.scss` to use a little less nesting, and enabled the `sass-lint` check for nested selectors. 

Here's a screenshot from before I started mucking with the sass:

![modal-before-basic](https://cloud.githubusercontent.com/assets/411788/16497130/c1320cc2-3eb2-11e6-9b29-1180b31ad3f3.png)

And here's what it looked like after:

![modal-after-basic](https://cloud.githubusercontent.com/assets/411788/16497147/d74ecaf4-3eb2-11e6-97f3-f28dfc7c92a0.png)

The only visible changes are a decreasing of the padding in the buttons to `10px` (so `frost-modal-input` doesn't have to override it). And a visible scrollbar b/c my cursor happened to be hovering over the modal in the second snapshot. 
# CHANGELOG
- **Reduced** specificity of SASS selectors
- **Added** `CONTRIBUTING.md` to inform potential contributors
  - **Added** `PULL_REQUEST_TEMPLATE.md` to ease intro into `pr-bumper`
