### PR TITLE
Support disabled confirm on frost-modal-form

### DIFF
--- a/addon/components/dialogs/form.js
+++ b/addon/components/dialogs/form.js
@@ -6,6 +6,11 @@ import PropTypesMixin, { PropTypes } from 'ember-prop-types'
 
 export default FrostModalBinding.extend(PropTypesMixin, {
 
+  // HACK: Needs to be replaced with a better proxy solution
+  isConfirmDisabled: Ember.computed('confirm.disabled', function () {
+    return this.get('confirm.disabled')
+  }),
+
   // == State properties ======================================================
 
   propTypes: {
@@ -15,6 +20,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
       text: PropTypes.string
     }),
     confirm: PropTypes.shape({
+      disabled: PropTypes.bool,
       isVisible: PropTypes.bool,
       text: PropTypes.string
     }),
@@ -43,6 +49,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
         cancel: this.cancel,
         confirm: this.confirm,
         content: this.form,
+        links: this.links,
         title: this.title
       }
     })

--- a/addon/templates/components/frost-modal-binding.hbs
+++ b/addon/templates/components/frost-modal-binding.hbs
@@ -4,6 +4,7 @@
     send=(hash
       animation=animation
       body=(component modal
+        isConfirmDisabled=isConfirmDisabled
         params=params
         hook=(concat hook '-modal')
         onCancel=(action '_onCancel')

--- a/addon/templates/components/frost-modal-dialog.hbs
+++ b/addon/templates/components/frost-modal-dialog.hbs
@@ -65,6 +65,7 @@
   }}
 
   {{frost-button
+    disabled=isConfirmDisabled
     hook=(concat hook '-confirm')
     isVisible=params.confirm.isVisible
     priority='primary'

--- a/tests/dummy/app/pods/demo/dynamic-updates/controller.js
+++ b/tests/dummy/app/pods/demo/dynamic-updates/controller.js
@@ -4,7 +4,10 @@ const {
   Controller,
   Object: EmberObject
 } = Ember
-import { task, timeout } from 'ember-concurrency'
+import {
+  task,
+  timeout
+} from 'ember-concurrency'
 
 export default Controller.extend({
   queryParams: [

--- a/tests/dummy/app/pods/demo/form/controller.js
+++ b/tests/dummy/app/pods/demo/form/controller.js
@@ -2,6 +2,10 @@ import Ember from 'ember'
 const {
   Controller
 } = Ember
+import {
+  task,
+  timeout
+} from 'ember-concurrency'
 
 export default Controller.extend({
   notifications: Ember.inject.service('notification-messages'),
@@ -37,7 +41,24 @@ export default Controller.extend({
 
   simpleBunsenValue: {},
 
+  isSomethingReady: false,
+  doSomething: task(function * () {
+    yield timeout(4000)
+    this.set('isSomethingReady', true)
+  }).drop(),
+
   actions: {
+    closeForm () {
+      this.set('isFormVisible', false)
+      this.get('doSomething').cancelAll()
+      this.set('isSomethingReady', false)
+    },
+
+    openForm () {
+      this.set('isFormVisible', true)
+      this.get('doSomething').perform()
+    },
+
     simpleBunsenChange (formValue) {
       this.set('simpleBunsenValue', formValue)
     },

--- a/tests/dummy/app/pods/demo/form/template.hbs
+++ b/tests/dummy/app/pods/demo/form/template.hbs
@@ -29,6 +29,9 @@
 
 {{! BEGIN-SNIPPET form }}
 {{frost-modal-form
+  confirm=(hash
+    disabled=(not isSomethingReady)
+  )
   form=(component 'frost-bunsen-form'
     bunsenModel=simpleBunsenModel
     hook='bunsen-form'
@@ -38,7 +41,7 @@
   hook='form-dialog'
   isVisible=isFormVisible
   title='Easy peasy'
-  onClose=(action (mut isFormVisible) false)
+  onClose=(action 'closeForm')
   onConfirm=(action 'notifyAndClear')
 }}
 {{! END-SNIPPET }}
@@ -63,7 +66,7 @@
       priority='primary'
       size='medium'
       text='Launch the modal'
-      onClick=(action (mut isFormVisible) true)
+      onClick=(action 'openForm')
     }}
   </div>
 </div>

--- a/tests/dummy/app/pods/demo/form/template.hbs
+++ b/tests/dummy/app/pods/demo/form/template.hbs
@@ -5,6 +5,7 @@
       text= // ('Cancel')
     )
     confirm=(hash
+      disabled= // (false)
       isVisible=  // (true)
       text= // ('Confirm')
     )


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- Added a hack to allow confirm buttons on the frost-modal-form to be disabled - a better proxy solution will be put in place shortly
