### PR TITLE
Adding a demo showing a summary message binding

### DIFF
--- a/tests/dummy/app/pods/demo/info/controller.js
+++ b/tests/dummy/app/pods/demo/info/controller.js
@@ -8,5 +8,6 @@ export default Controller.extend({
     'isInfoVisible'
   ],
 
+  boringSummary: 'I just thought you should know',
   isInfoVisible: false
 })

--- a/tests/dummy/app/pods/demo/info/template.hbs
+++ b/tests/dummy/app/pods/demo/info/template.hbs
@@ -27,7 +27,7 @@
 {{frost-modal-info-message
   hook='info-dialog'
   isVisible=isInfoVisible
-  summary='I just thought you should know'
+  summary=boringSummary
   title="I'm quite boring"
   onClose=(action (mut isInfoVisible) false)
 }}


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- Updated the info dialog demo to show a simple summary message binding
