### PR TITLE
Fixing the observer binding for params

### DIFF
--- a/addon/components/dialogs/about.js
+++ b/addon/components/dialogs/about.js
@@ -1,5 +1,8 @@
 import Ember from 'ember'
-const { assign } = Ember
+const {
+  assign,
+  computed
+} = Ember
 import FrostModalBinding from '../frost-modal-binding'
 import { about } from '../../helpers/frost-modal-animation'
 import PropTypesMixin, { PropTypes } from 'ember-prop-types'
@@ -38,17 +41,22 @@ export default FrostModalBinding.extend(PropTypesMixin, {
       animation: about,
       classModifier: 'about',
       closeOnOutsideClick: true,
-      modal: 'frost-modal-about-dialog',
-      params: {
-        brandingStrip: this.brandingStrip,
-        copyright: this.copyright,
-        logo: this.logo,
-        product: this.product,
-        versions: this.versions
-      }
+      modal: 'frost-modal-about-dialog'
     })
 
     return defaultProps
-  }
+  },
+
+  // == Computed properties ===================================================
+
+  params: computed(function () {
+    return {
+      brandingStrip: this.brandingStrip,
+      copyright: this.copyright,
+      logo: this.logo,
+      product: this.product,
+      versions: this.versions
+    }
+  })
 
 })

--- a/addon/components/dialogs/form.js
+++ b/addon/components/dialogs/form.js
@@ -1,15 +1,13 @@
 import Ember from 'ember'
-const { assign } = Ember
+const {
+  assign,
+  computed
+} = Ember
 import FrostModalBinding from '../frost-modal-binding'
 import { form } from '../../helpers/frost-modal-animation'
 import PropTypesMixin, { PropTypes } from 'ember-prop-types'
 
 export default FrostModalBinding.extend(PropTypesMixin, {
-
-  // HACK: Needs to be replaced with a better proxy solution
-  isConfirmDisabled: Ember.computed('confirm.disabled', function () {
-    return this.get('confirm.disabled')
-  }),
 
   // == State properties ======================================================
 
@@ -44,17 +42,22 @@ export default FrostModalBinding.extend(PropTypesMixin, {
     assign(defaultProps, {
       animation: form,
       classModifier: 'form',
-      modal: 'frost-modal-dialog',
-      params: {
-        cancel: this.cancel,
-        confirm: this.confirm,
-        content: this.form,
-        links: this.links,
-        title: this.title
-      }
+      modal: 'frost-modal-dialog'
     })
 
     return defaultProps
-  }
+  },
+
+  // == Computed properties ===================================================
+
+  params: computed(function () {
+    return {
+      cancel: this.cancel,
+      confirm: this.confirm,
+      content: this.form,
+      links: this.links,
+      title: this.title
+    }
+  })
 
 })

--- a/addon/components/dialogs/messages/confirm.js
+++ b/addon/components/dialogs/messages/confirm.js
@@ -1,5 +1,8 @@
 import Ember from 'ember'
-const { assign } = Ember
+const {
+  assign,
+  computed
+} = Ember
 import FrostModalBinding from '../../frost-modal-binding'
 import { message } from '../../../helpers/frost-modal-animation'
 import PropTypesMixin, { PropTypes } from 'ember-prop-types'
@@ -40,22 +43,27 @@ export default FrostModalBinding.extend(PropTypesMixin, {
     assign(defaultProps, {
       animation: message,
       classModifier: 'message',
-      modal: 'frost-modal-dialog',
-      params: {
-        cancel: this.cancel,
-        confirm: this.confirm,
-        content: this.details,
-        icon: {
-          name: 'warn',
-          pack: 'frost-modal'
-        },
-        links: this.links,
-        summary: this.summary,
-        title: this.title
-      }
+      modal: 'frost-modal-dialog'
     })
 
     return defaultProps
-  }
+  },
+
+  // == Computed properties ===================================================
+
+  params: computed(function () {
+    return {
+      cancel: this.cancel,
+      confirm: this.confirm,
+      content: this.details,
+      icon: {
+        name: 'warn',
+        pack: 'frost-modal'
+      },
+      links: this.links,
+      summary: this.summary,
+      title: this.title
+    }
+  })
 
 })

--- a/addon/components/dialogs/messages/error.js
+++ b/addon/components/dialogs/messages/error.js
@@ -1,6 +1,7 @@
 import Ember from 'ember'
 const {
   assign,
+  computed,
   getWithDefault
 } = Ember
 import FrostModalBinding from '../../frost-modal-binding'
@@ -38,27 +39,32 @@ export default FrostModalBinding.extend(PropTypesMixin, {
     assign(defaultProps, {
       animation: message,
       classModifier: 'message',
-      modal: 'frost-modal-dialog',
-      params: {
-        cancel: {
-          isVisible: false
-        },
-        confirm: {
-          isVisible: getWithDefault(this, 'confirm.isVisible', true),
-          text: getWithDefault(this, 'confirm.text', 'Close')
-        },
-        content: this.details,
-        icon: {
-          name: 'error',
-          pack: 'frost-modal'
-        },
-        links: this.links,
-        summary: this.summary,
-        title: this.title
-      }
+      modal: 'frost-modal-dialog'
     })
 
     return defaultProps
-  }
+  },
+
+  // == Computed properties ===================================================
+
+  params: computed(function () {
+    return {
+      cancel: {
+        isVisible: false
+      },
+      confirm: {
+        isVisible: getWithDefault(this, 'confirm.isVisible', true),
+        text: getWithDefault(this, 'confirm.text', 'Close')
+      },
+      content: this.details,
+      icon: {
+        name: 'error',
+        pack: 'frost-modal'
+      },
+      links: this.links,
+      summary: this.summary,
+      title: this.title
+    }
+  })
 
 })

--- a/addon/components/dialogs/messages/info.js
+++ b/addon/components/dialogs/messages/info.js
@@ -1,6 +1,7 @@
 import Ember from 'ember'
 const {
   assign,
+  computed,
   getWithDefault
 } = Ember
 import FrostModalBinding from '../../frost-modal-binding'
@@ -38,27 +39,32 @@ export default FrostModalBinding.extend(PropTypesMixin, {
     assign(defaultProps, {
       animation: message,
       classModifier: 'message',
-      modal: 'frost-modal-dialog',
-      params: {
-        cancel: {
-          isVisible: false
-        },
-        confirm: {
-          isVisible: getWithDefault(this, 'confirm.isVisible', true),
-          text: getWithDefault(this, 'confirm.text', 'Ok')
-        },
-        content: this.details,
-        icon: {
-          name: 'info',
-          pack: 'frost-modal'
-        },
-        links: this.links,
-        summary: this.summary,
-        title: this.title
-      }
+      modal: 'frost-modal-dialog'
     })
 
     return defaultProps
-  }
+  },
+
+  // == Computed properties ===================================================
+
+  params: computed(function () {
+    return {
+      cancel: {
+        isVisible: false
+      },
+      confirm: {
+        isVisible: getWithDefault(this, 'confirm.isVisible', true),
+        text: getWithDefault(this, 'confirm.text', 'Ok')
+      },
+      content: this.details,
+      icon: {
+        name: 'info',
+        pack: 'frost-modal'
+      },
+      links: this.links,
+      summary: this.summary,
+      title: this.title
+    }
+  })
 
 })

--- a/addon/components/dialogs/messages/warn.js
+++ b/addon/components/dialogs/messages/warn.js
@@ -1,5 +1,8 @@
 import Ember from 'ember'
-const { assign } = Ember
+const {
+  assign,
+  computed
+} = Ember
 import FrostModalBinding from '../../frost-modal-binding'
 import { message } from '../../../helpers/frost-modal-animation'
 import PropTypesMixin, { PropTypes } from 'ember-prop-types'
@@ -40,22 +43,27 @@ export default FrostModalBinding.extend(PropTypesMixin, {
     assign(defaultProps, {
       animation: message,
       classModifier: 'message',
-      modal: 'frost-modal-dialog',
-      params: {
-        cancel: this.cancel,
-        confirm: this.confirm,
-        content: this.details,
-        icon: {
-          name: 'warn',
-          pack: 'frost-modal'
-        },
-        links: this.links,
-        summary: this.summary,
-        title: this.title
-      }
+      modal: 'frost-modal-dialog'
     })
 
     return defaultProps
-  }
+  },
+
+  // == Computed properties ===================================================
+
+  params: computed(function () {
+    return {
+      cancel: this.cancel,
+      confirm: this.confirm,
+      content: this.details,
+      icon: {
+        name: 'warn',
+        pack: 'frost-modal'
+      },
+      links: this.links,
+      summary: this.summary,
+      title: this.title
+    }
+  })
 
 })

--- a/addon/components/frost-modal-binding.js
+++ b/addon/components/frost-modal-binding.js
@@ -53,6 +53,10 @@ const FrostModalBinding = Component.extend(PropTypesMixin, {
     this.get('modalService').setState(this.modalComponentName, this.isVisible, this.noBlur)
   },
 
+  didUpdateAttrs () {
+    this.notifyPropertyChange('params')
+  },
+
   // == Actions ===============================================================
 
   actions: {

--- a/addon/templates/components/frost-modal-binding.hbs
+++ b/addon/templates/components/frost-modal-binding.hbs
@@ -4,7 +4,6 @@
     send=(hash
       animation=animation
       body=(component modal
-        isConfirmDisabled=isConfirmDisabled
         params=params
         hook=(concat hook '-modal')
         onCancel=(action '_onCancel')

--- a/addon/templates/components/frost-modal-dialog.hbs
+++ b/addon/templates/components/frost-modal-dialog.hbs
@@ -65,7 +65,7 @@
   }}
 
   {{frost-button
-    disabled=isConfirmDisabled
+    disabled=params.confirm.disabled
     hook=(concat hook '-confirm')
     isVisible=params.confirm.isVisible
     priority='primary'

--- a/tests/dummy/app/pods/demo/info/controller.js
+++ b/tests/dummy/app/pods/demo/info/controller.js
@@ -2,12 +2,38 @@ import Ember from 'ember'
 const {
   Controller
 } = Ember
+import {
+  task,
+  timeout
+} from 'ember-concurrency'
 
 export default Controller.extend({
   queryParams: [
     'isInfoVisible'
   ],
 
+  boringConfirm: 'Ok',
   boringSummary: 'I just thought you should know',
-  isInfoVisible: false
+  isInfoVisible: false,
+
+  excitingSummary: task(function * () {
+    yield timeout(4000)
+    this.set('boringSummary', '...or am I?')
+    yield timeout(2000)
+    this.set('boringConfirm', 'Yup, still boring...')
+  }).drop(),
+
+  actions: {
+    closeInfo () {
+      this.set('isInfoVisible', false)
+      this.get('excitingSummary').cancelAll()
+      this.set('boringSummary', 'I just thought you should know')
+      this.set('boringConfirm', 'Ok')
+    },
+
+    openInfo () {
+      this.set('isInfoVisible', true)
+      this.get('excitingSummary').perform()
+    }
+  }
 })

--- a/tests/dummy/app/pods/demo/info/template.hbs
+++ b/tests/dummy/app/pods/demo/info/template.hbs
@@ -25,11 +25,14 @@
 
 {{! BEGIN-SNIPPET info }}
 {{frost-modal-info-message
+  confirm=(hash
+    text=boringConfirm
+  )
   hook='info-dialog'
   isVisible=isInfoVisible
   summary=boringSummary
   title="I'm quite boring"
-  onClose=(action (mut isInfoVisible) false)
+  onClose=(action 'closeInfo')
 }}
 {{! END-SNIPPET }}
 
@@ -53,7 +56,7 @@
       priority='primary'
       size='medium'
       text='Launch the modal'
-      onClick=(action (mut isInfoVisible) true)
+      onClick=(action 'openInfo')
     }}
   </div>
 </div>


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- Removed the hack for dynamically disabling confirm on forms
- Added a computed property for params that fires whenever attributes are updated
- Updated the info demo to demonstrate this ability in both the summary and confirm params
