### PR TITLE
Add support for footer text

### DIFF
--- a/addon/components/dialogs/form.js
+++ b/addon/components/dialogs/form.js
@@ -22,6 +22,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
       isVisible: PropTypes.bool,
       text: PropTypes.string
     }),
+    footer: PropTypes.string,
     form: PropTypes.oneOfType([
       PropTypes.object,
       PropTypes.EmberObject
@@ -56,6 +57,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
       cancel: this.cancel,
       confirm: this.confirm,
       content: this.form,
+      footer: this.footer,
       links: this.links,
       subtitle: this.subtitle,
       title: this.title

--- a/addon/components/dialogs/messages/confirm.js
+++ b/addon/components/dialogs/messages/confirm.js
@@ -25,6 +25,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
       PropTypes.object,
       PropTypes.EmberObject
     ]),
+    footer: PropTypes.string,
     isVisible: PropTypes.bool.isRequired,
     links: PropTypes.EmberObject,
     subtitle: PropTypes.string,
@@ -57,6 +58,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
       cancel: this.cancel,
       confirm: this.confirm,
       content: this.details,
+      footer: this.footer,
       icon: {
         name: 'warn',
         pack: 'frost-modal'

--- a/addon/components/dialogs/messages/error.js
+++ b/addon/components/dialogs/messages/error.js
@@ -22,6 +22,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
       PropTypes.object,
       PropTypes.EmberObject
     ]),
+    footer: PropTypes.string,
     isVisible: PropTypes.bool.isRequired,
     links: PropTypes.array,
     subtitle: PropTypes.string,
@@ -58,6 +59,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
         text: getWithDefault(this, 'confirm.text', 'Close')
       },
       content: this.details,
+      footer: this.footer,
       icon: {
         name: 'error',
         pack: 'frost-modal'

--- a/addon/components/dialogs/messages/info.js
+++ b/addon/components/dialogs/messages/info.js
@@ -22,6 +22,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
       PropTypes.object,
       PropTypes.EmberObject
     ]),
+    footer: PropTypes.string,
     isVisible: PropTypes.bool.isRequired,
     links: PropTypes.array,
     subtitle: PropTypes.string,
@@ -58,6 +59,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
         text: getWithDefault(this, 'confirm.text', 'Ok')
       },
       content: this.details,
+      footer: this.footer,
       icon: {
         name: 'info',
         pack: 'frost-modal'

--- a/addon/components/dialogs/messages/warn.js
+++ b/addon/components/dialogs/messages/warn.js
@@ -25,6 +25,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
       PropTypes.object,
       PropTypes.EmberObject
     ]),
+    footer: PropTypes.string,
     isVisible: PropTypes.bool.isRequired,
     links: PropTypes.array,
     subtitle: PropTypes.string,
@@ -57,6 +58,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
       cancel: this.cancel,
       confirm: this.confirm,
       content: this.details,
+      footer: this.footer,
       icon: {
         name: 'warn',
         pack: 'frost-modal'

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -73,6 +73,12 @@ $frost-modal-overflow-shadow-color: rgba(0, 0, 0, .13);
     > * {
       margin-left: 10px;
     }
+
+    &-text {
+      position: absolute;
+      left: 30px;
+      color: $frost-color-grey-3;
+    }
   }
 
   &-header {

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -66,7 +66,7 @@ $frost-modal-overflow-shadow-color: rgba(0, 0, 0, .13);
     align-items: center;
     justify-content: flex-end;
     min-height: 70px;
-    padding-right: 20px;
+    padding: 0 20px;
     border-top: 1px solid $frost-color-lgrey-1;
     background-color: $frost-modal-dialog-footer-background-color;
 
@@ -75,8 +75,8 @@ $frost-modal-overflow-shadow-color: rgba(0, 0, 0, .13);
     }
 
     &-text {
-      position: absolute;
-      left: 30px;
+      margin-right: auto;
+      margin-left: 0;
       color: $frost-color-grey-3;
     }
   }

--- a/addon/templates/components/frost-modal-dialog.hbs
+++ b/addon/templates/components/frost-modal-dialog.hbs
@@ -58,6 +58,10 @@
   {{/if}}
   {{! END-SNIPPET }}
 
+  {{#if params.footer}}
+    <div class="frost-modal-dialog-footer-text">{{params.footer}}</div>
+  {{/if}}
+
   {{frost-button
     hook=(concat hook '-cancel')
     isVisible=params.cancel.isVisible

--- a/tests/dummy/app/pods/demo/confirm/template.hbs
+++ b/tests/dummy/app/pods/demo/confirm/template.hbs
@@ -11,6 +11,7 @@
     details=(component 'foo'
       bar= // e.g. props for 'foo'
     )
+    footer= // e.g. 'Foo bar'
     isVisible= // Required binding
     links=(array
       (hash

--- a/tests/dummy/app/pods/demo/error/template.hbs
+++ b/tests/dummy/app/pods/demo/error/template.hbs
@@ -7,6 +7,7 @@
     details=(component 'foo'
       bar= // e.g. props for 'foo'
     )
+    footer= // e.g. 'Foo bar'
     isVisible= // Required binding
     links=(array
       (hash

--- a/tests/dummy/app/pods/demo/form/template.hbs
+++ b/tests/dummy/app/pods/demo/form/template.hbs
@@ -9,6 +9,7 @@
       isVisible=  // (true)
       text= // ('Confirm')
     )
+    footer= // e.g. 'Foo bar'
     form=(component 'frost-bunsen-form'
       bar= // e.g. props for 'foo'
     )
@@ -34,6 +35,7 @@
   confirm=(hash
     disabled=(not isSomethingReady)
   )
+  footer='Foo bar'
   form=(component 'frost-bunsen-form'
     bunsenModel=simpleBunsenModel
     hook='bunsen-form'

--- a/tests/dummy/app/pods/demo/info/template.hbs
+++ b/tests/dummy/app/pods/demo/info/template.hbs
@@ -7,6 +7,7 @@
     details=(component 'foo'
       bar= // e.g. props for 'foo'
     )
+    footer= // e.g. 'Foo bar'
     isVisible= // Required binding
     links=(array
       (hash

--- a/tests/dummy/app/pods/demo/warn/template.hbs
+++ b/tests/dummy/app/pods/demo/warn/template.hbs
@@ -11,6 +11,7 @@
     details=(component 'foo'
       bar= // e.g. props for 'foo'
     )
+    footer= // e.g. 'Foo bar'
     isVisible= // Required binding
     links=(array
       (hash

--- a/tests/integration/components/frost-modal-error-message-test.js
+++ b/tests/integration/components/frost-modal-error-message-test.js
@@ -40,6 +40,7 @@ describeComponent(
               isVisible=false
             )
             details=(component 'list-em' things=things)
+            footer=footer
             hook='error-dialog'
             isVisible=isModalVisible
             subtitle=subtitle
@@ -89,6 +90,28 @@ describeComponent(
 
       it('does not render subtitle DOM', function () {
         expect(this.$('.frost-modal-dialog-header-subtitle')).to.have.length(0)
+      })
+    })
+
+    describe('when footer text present', function () {
+      beforeEach(function () {
+        this.set('footer', 'Foo bar')
+      })
+
+      it('renders footer text', function () {
+        const $footer = this.$('.frost-modal-dialog-footer-text')
+        expect($footer).to.have.length(1)
+        expect($footer.text()).to.equal('Foo bar')
+      })
+    })
+
+    describe('when footer text not present', function () {
+      beforeEach(function () {
+        this.set('footer', undefined)
+      })
+
+      it('does not render footer text DOM', function () {
+        expect(this.$('.frost-modal-dialog-footer-text')).to.have.length(0)
       })
     })
   }

--- a/tests/integration/components/frost-modal-form-test.js
+++ b/tests/integration/components/frost-modal-form-test.js
@@ -63,6 +63,7 @@ describeComponent(
           {{frost-modal-outlet}}
 
           {{frost-modal-form
+            footer=footer
             form=(component 'frost-bunsen-form'
               bunsenModel=simpleBunsenModel
               hook='bunsen-form'
@@ -113,6 +114,28 @@ describeComponent(
 
       it('does not render subtitle DOM', function () {
         expect(this.$('.frost-modal-dialog-header-subtitle')).to.have.length(0)
+      })
+    })
+
+    describe('when footer text present', function () {
+      beforeEach(function () {
+        this.set('footer', 'Foo bar')
+      })
+
+      it('renders footer text', function () {
+        const $footer = this.$('.frost-modal-dialog-footer-text')
+        expect($footer).to.have.length(1)
+        expect($footer.text()).to.equal('Foo bar')
+      })
+    })
+
+    describe('when footer text not present', function () {
+      beforeEach(function () {
+        this.set('footer', undefined)
+      })
+
+      it('does not render footer text DOM', function () {
+        expect(this.$('.frost-modal-dialog-footer-text')).to.have.length(0)
       })
     })
   }

--- a/tests/integration/components/frost-modal-info-message-test.js
+++ b/tests/integration/components/frost-modal-info-message-test.js
@@ -31,6 +31,7 @@ describeComponent(
           {{frost-modal-outlet}}
 
           {{frost-modal-info-message
+            footer=footer
             hook='info-dialog'
             isVisible=isModalVisible
             subtitle=subtitle
@@ -80,6 +81,28 @@ describeComponent(
 
       it('does not render subtitle DOM', function () {
         expect(this.$('.frost-modal-dialog-header-subtitle')).to.have.length(0)
+      })
+    })
+
+    describe('when footer text present', function () {
+      beforeEach(function () {
+        this.set('footer', 'Foo bar')
+      })
+
+      it('renders footer text', function () {
+        const $footer = this.$('.frost-modal-dialog-footer-text')
+        expect($footer).to.have.length(1)
+        expect($footer.text()).to.equal('Foo bar')
+      })
+    })
+
+    describe('when footer text not present', function () {
+      beforeEach(function () {
+        this.set('footer', undefined)
+      })
+
+      it('does not render footer text DOM', function () {
+        expect(this.$('.frost-modal-dialog-footer-text')).to.have.length(0)
       })
     })
   }

--- a/tests/integration/components/frost-modal-warn-message-test.js
+++ b/tests/integration/components/frost-modal-warn-message-test.js
@@ -40,6 +40,7 @@ describeComponent(
             cancel=(hash
               text='Nope'
             )
+            footer=footer
             hook=hook
             isVisible=isModalVisible
             subtitle=subtitle
@@ -92,6 +93,28 @@ describeComponent(
 
       it('does not render subtitle DOM', function () {
         expect(this.$('.frost-modal-dialog-header-subtitle')).to.have.length(0)
+      })
+    })
+
+    describe('when footer text present', function () {
+      beforeEach(function () {
+        this.set('footer', 'Foo bar')
+      })
+
+      it('renders footer text', function () {
+        const $footer = this.$('.frost-modal-dialog-footer-text')
+        expect($footer).to.have.length(1)
+        expect($footer.text()).to.equal('Foo bar')
+      })
+    })
+
+    describe('when footer text not present', function () {
+      beforeEach(function () {
+        this.set('footer', undefined)
+      })
+
+      it('does not render footer text DOM', function () {
+        expect(this.$('.frost-modal-dialog-footer-text')).to.have.length(0)
       })
     })
   }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Added** new `footer` property to modals that allows arbitrary text to be rendered in the left side of the footer.
