### PR TITLE
Add support for more buttons in modal footer

### DIFF
--- a/addon/components/dialogs/form.js
+++ b/addon/components/dialogs/form.js
@@ -13,6 +13,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
 
   propTypes: {
     // Options
+    buttons: PropTypes.array,
     cancel: PropTypes.shape({
       isVisible: PropTypes.bool,
       text: PropTypes.string
@@ -28,6 +29,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
       PropTypes.EmberObject
     ]).isRequired,
     isVisible: PropTypes.bool.isRequired,
+    links: PropTypes.array,
     subtitle: PropTypes.string,
     targetOutlet: PropTypes.string,
     title: PropTypes.string.isRequired,
@@ -54,6 +56,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
 
   params: computed(function () {
     return {
+      buttons: this.buttons,
       cancel: this.cancel,
       confirm: this.confirm,
       content: this.form,

--- a/addon/components/dialogs/messages/confirm.js
+++ b/addon/components/dialogs/messages/confirm.js
@@ -13,6 +13,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
 
   propTypes: {
     // Options
+    buttons: PropTypes.array,
     cancel: PropTypes.shape({
       isVisible: PropTypes.bool,
       text: PropTypes.string
@@ -27,7 +28,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
     ]),
     footer: PropTypes.string,
     isVisible: PropTypes.bool.isRequired,
-    links: PropTypes.EmberObject,
+    links: PropTypes.array,
     subtitle: PropTypes.string,
     summary: PropTypes.string,
     targetOutlet: PropTypes.string,
@@ -55,6 +56,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
 
   params: computed(function () {
     return {
+      buttons: this.buttons,
       cancel: this.cancel,
       confirm: this.confirm,
       content: this.details,

--- a/addon/components/dialogs/messages/error.js
+++ b/addon/components/dialogs/messages/error.js
@@ -14,6 +14,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
 
   propTypes: {
     // Options
+    buttons: PropTypes.array,
     confirm: PropTypes.shape({
       isVisible: PropTypes.bool,
       text: PropTypes.string
@@ -51,6 +52,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
 
   params: computed(function () {
     return {
+      buttons: this.buttons,
       cancel: {
         isVisible: false
       },

--- a/addon/components/dialogs/messages/info.js
+++ b/addon/components/dialogs/messages/info.js
@@ -14,6 +14,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
 
   propTypes: {
     // Options
+    buttons: PropTypes.array,
     confirm: PropTypes.shape({
       isVisible: PropTypes.bool,
       text: PropTypes.string
@@ -51,6 +52,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
 
   params: computed(function () {
     return {
+      buttons: this.buttons,
       cancel: {
         isVisible: false
       },

--- a/addon/components/dialogs/messages/warn.js
+++ b/addon/components/dialogs/messages/warn.js
@@ -13,6 +13,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
 
   propTypes: {
     // Options
+    buttons: PropTypes.array,
     cancel: PropTypes.shape({
       isVisible: PropTypes.bool,
       text: PropTypes.string
@@ -55,6 +56,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
 
   params: computed(function () {
     return {
+      buttons: this.buttons,
       cancel: this.cancel,
       confirm: this.confirm,
       content: this.details,

--- a/addon/templates/components/frost-modal-dialog.hbs
+++ b/addon/templates/components/frost-modal-dialog.hbs
@@ -71,6 +71,18 @@
     onClick=onCancel
   }}
 
+  {{#each params.buttons as |button index|}}
+    {{frost-button
+      hook=(concat hook '-button-' index)
+      icon=button.icon
+      pack=button.pack
+      priority=button.priority
+      size='medium'
+      onClick=button.onClick
+      text=button.text
+    }}
+  {{/each}}
+
   {{frost-button
     disabled=params.confirm.disabled
     hook=(concat hook '-confirm')

--- a/addon/templates/components/frost-modal-dialog.hbs
+++ b/addon/templates/components/frost-modal-dialog.hbs
@@ -73,6 +73,7 @@
 
   {{#each params.buttons as |button index|}}
     {{frost-button
+      disabled=button.disabled
       hook=(concat hook '-button-' index)
       icon=button.icon
       pack=button.pack

--- a/tests/dummy/app/pods/demo/confirm/template.hbs
+++ b/tests/dummy/app/pods/demo/confirm/template.hbs
@@ -2,6 +2,7 @@
   {{frost-modal-confirm-message
     buttons=(array
       (hash
+        disabled= // true
         icon= // e.g. 'info'
         onClick= // e.g. (action 'info')
         pack= // e.g. 'frost'

--- a/tests/dummy/app/pods/demo/confirm/template.hbs
+++ b/tests/dummy/app/pods/demo/confirm/template.hbs
@@ -1,5 +1,14 @@
 {{!-- BEGIN-SNIPPET confirm-api }}
   {{frost-modal-confirm-message
+    buttons=(array
+      (hash
+        icon= // e.g. 'info'
+        onClick= // e.g. (action 'info')
+        pack= // e.g. 'frost'
+        priority= // ['primary', etc.]
+        text= // e.g. 'Foo'
+      )
+    )
     cancel=(hash
       isVisible= // (true)
       text= // ('Cancel')

--- a/tests/dummy/app/pods/demo/error/template.hbs
+++ b/tests/dummy/app/pods/demo/error/template.hbs
@@ -2,6 +2,7 @@
   {{frost-modal-error-message
     buttons=(array
       (hash
+        disabled= // true
         icon= // e.g. 'info'
         onClick= // e.g. (action 'info')
         pack= // e.g. 'frost'

--- a/tests/dummy/app/pods/demo/error/template.hbs
+++ b/tests/dummy/app/pods/demo/error/template.hbs
@@ -1,5 +1,14 @@
 {{!-- BEGIN-SNIPPET error-api }}
   {{frost-modal-error-message
+    buttons=(array
+      (hash
+        icon= // e.g. 'info'
+        onClick= // e.g. (action 'info')
+        pack= // e.g. 'frost'
+        priority= // ['primary', etc.]
+        text= // e.g. 'Foo'
+      )
+    )
     confirm=(hash
       isVisible= // (true)
       text= // ('Close')

--- a/tests/dummy/app/pods/demo/form/controller.js
+++ b/tests/dummy/app/pods/demo/form/controller.js
@@ -59,6 +59,10 @@ export default Controller.extend({
       this.get('doSomething').perform()
     },
 
+    info () {
+      window.alert('OMG!')
+    },
+
     simpleBunsenChange (formValue) {
       this.set('simpleBunsenValue', formValue)
     },

--- a/tests/dummy/app/pods/demo/form/template.hbs
+++ b/tests/dummy/app/pods/demo/form/template.hbs
@@ -1,5 +1,14 @@
 {{!-- BEGIN-SNIPPET form-api }}
   {{frost-modal-form
+    buttons=(array
+      (hash
+        icon= // e.g. 'info'
+        onClick= // e.g. (action 'info')
+        pack= // e.g. 'frost'
+        priority= // ['primary', etc.]
+        text= // e.g. 'Foo'
+      )
+    )
     cancel=(hash
       isVisible= // (true)
       text= // ('Cancel')
@@ -32,6 +41,15 @@
 
 {{! BEGIN-SNIPPET form }}
 {{frost-modal-form
+  buttons=(array
+    (hash
+      icon='info'
+      onClick=(action 'info')
+      pack='frost'
+      priority='secondary'
+      text='Info'
+    )
+  )
   confirm=(hash
     disabled=(not isSomethingReady)
   )

--- a/tests/dummy/app/pods/demo/form/template.hbs
+++ b/tests/dummy/app/pods/demo/form/template.hbs
@@ -2,6 +2,7 @@
   {{frost-modal-form
     buttons=(array
       (hash
+        disabled= // true
         icon= // e.g. 'info'
         onClick= // e.g. (action 'info')
         pack= // e.g. 'frost'

--- a/tests/dummy/app/pods/demo/info/template.hbs
+++ b/tests/dummy/app/pods/demo/info/template.hbs
@@ -2,6 +2,7 @@
   {{frost-modal-info-message
     buttons=(array
       (hash
+        disabled= // true
         icon= // e.g. 'info'
         onClick= // e.g. (action 'info')
         pack= // e.g. 'frost'

--- a/tests/dummy/app/pods/demo/info/template.hbs
+++ b/tests/dummy/app/pods/demo/info/template.hbs
@@ -1,5 +1,14 @@
 {{!-- BEGIN-SNIPPET info-api }}
   {{frost-modal-info-message
+    buttons=(array
+      (hash
+        icon= // e.g. 'info'
+        onClick= // e.g. (action 'info')
+        pack= // e.g. 'frost'
+        priority= // ['primary', etc.]
+        text= // e.g. 'Foo'
+      )
+    )
     confirm=(hash
       isVisible= // (true)
       text= // ('Ok')

--- a/tests/dummy/app/pods/demo/warn/template.hbs
+++ b/tests/dummy/app/pods/demo/warn/template.hbs
@@ -1,5 +1,14 @@
 {{!-- BEGIN-SNIPPET warn-api }}
   {{frost-modal-warn-message
+    buttons=(array
+      (hash
+        icon= // e.g. 'info'
+        onClick= // e.g. (action 'info')
+        pack= // e.g. 'frost'
+        priority= // ['primary', etc.]
+        text= // e.g. 'Foo'
+      )
+    )
     cancel=(hash
       isVisible= // (true)
       text= // ('Cancel')

--- a/tests/dummy/app/pods/demo/warn/template.hbs
+++ b/tests/dummy/app/pods/demo/warn/template.hbs
@@ -2,6 +2,7 @@
   {{frost-modal-warn-message
     buttons=(array
       (hash
+        disabled= // true
         icon= // e.g. 'info'
         onClick= // e.g. (action 'info')
         pack= // e.g. 'frost'

--- a/tests/integration/components/frost-modal-error-message-test.js
+++ b/tests/integration/components/frost-modal-error-message-test.js
@@ -36,6 +36,7 @@ describeComponent(
         this.render(hbs`
           {{frost-modal-outlet}}
           {{frost-modal-error-message
+            buttons=buttons
             confirm=(hash
               isVisible=false
             )
@@ -112,6 +113,35 @@ describeComponent(
 
       it('does not render footer text DOM', function () {
         expect(this.$('.frost-modal-dialog-footer-text')).to.have.length(0)
+      })
+    })
+
+    describe('when buttons present', function () {
+      beforeEach(function () {
+        this.set('buttons', [
+          {
+            priority: 'secondary',
+            text: 'Foo'
+          },
+          {
+            priority: 'secondary',
+            text: 'Bar'
+          }
+        ])
+      })
+
+      it('renders custom buttons plus cancel and create buttons', function () {
+        expect(this.$('.frost-modal-dialog-footer button')).to.have.length(4)
+      })
+    })
+
+    describe('when buttons not present', function () {
+      beforeEach(function () {
+        this.set('buttons', undefined)
+      })
+
+      it('only renders cancel and create buttons', function () {
+        expect(this.$('.frost-modal-dialog-footer button')).to.have.length(2)
       })
     })
   }

--- a/tests/integration/components/frost-modal-form-test.js
+++ b/tests/integration/components/frost-modal-form-test.js
@@ -63,6 +63,7 @@ describeComponent(
           {{frost-modal-outlet}}
 
           {{frost-modal-form
+            buttons=buttons
             footer=footer
             form=(component 'frost-bunsen-form'
               bunsenModel=simpleBunsenModel
@@ -136,6 +137,35 @@ describeComponent(
 
       it('does not render footer text DOM', function () {
         expect(this.$('.frost-modal-dialog-footer-text')).to.have.length(0)
+      })
+    })
+
+    describe('when buttons present', function () {
+      beforeEach(function () {
+        this.set('buttons', [
+          {
+            priority: 'secondary',
+            text: 'Foo'
+          },
+          {
+            priority: 'secondary',
+            text: 'Bar'
+          }
+        ])
+      })
+
+      it('renders custom buttons plus cancel and create buttons', function () {
+        expect(this.$('.frost-modal-dialog-footer button')).to.have.length(4)
+      })
+    })
+
+    describe('when buttons not present', function () {
+      beforeEach(function () {
+        this.set('buttons', undefined)
+      })
+
+      it('only renders cancel and create buttons', function () {
+        expect(this.$('.frost-modal-dialog-footer button')).to.have.length(2)
       })
     })
   }

--- a/tests/integration/components/frost-modal-info-message-test.js
+++ b/tests/integration/components/frost-modal-info-message-test.js
@@ -31,6 +31,7 @@ describeComponent(
           {{frost-modal-outlet}}
 
           {{frost-modal-info-message
+            buttons=buttons
             footer=footer
             hook='info-dialog'
             isVisible=isModalVisible
@@ -103,6 +104,35 @@ describeComponent(
 
       it('does not render footer text DOM', function () {
         expect(this.$('.frost-modal-dialog-footer-text')).to.have.length(0)
+      })
+    })
+
+    describe('when buttons present', function () {
+      beforeEach(function () {
+        this.set('buttons', [
+          {
+            priority: 'secondary',
+            text: 'Foo'
+          },
+          {
+            priority: 'secondary',
+            text: 'Bar'
+          }
+        ])
+      })
+
+      it('renders custom buttons plus cancel and create buttons', function () {
+        expect(this.$('.frost-modal-dialog-footer button')).to.have.length(4)
+      })
+    })
+
+    describe('when buttons not present', function () {
+      beforeEach(function () {
+        this.set('buttons', undefined)
+      })
+
+      it('only renders cancel and create buttons', function () {
+        expect(this.$('.frost-modal-dialog-footer button')).to.have.length(2)
       })
     })
   }

--- a/tests/integration/components/frost-modal-warn-message-test.js
+++ b/tests/integration/components/frost-modal-warn-message-test.js
@@ -37,6 +37,7 @@ describeComponent(
         this.render(hbs`
           {{frost-modal-outlet}}
           {{frost-modal-warn-message
+            buttons=buttons
             cancel=(hash
               text='Nope'
             )
@@ -115,6 +116,35 @@ describeComponent(
 
       it('does not render footer text DOM', function () {
         expect(this.$('.frost-modal-dialog-footer-text')).to.have.length(0)
+      })
+    })
+
+    describe('when buttons present', function () {
+      beforeEach(function () {
+        this.set('buttons', [
+          {
+            priority: 'secondary',
+            text: 'Foo'
+          },
+          {
+            priority: 'secondary',
+            text: 'Bar'
+          }
+        ])
+      })
+
+      it('renders custom buttons plus cancel and create buttons', function () {
+        expect(this.$('.frost-modal-dialog-footer button')).to.have.length(4)
+      })
+    })
+
+    describe('when buttons not present', function () {
+      beforeEach(function () {
+        this.set('buttons', undefined)
+      })
+
+      it('only renders cancel and create buttons', function () {
+        expect(this.$('.frost-modal-dialog-footer button')).to.have.length(2)
       })
     })
   }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Added** new `buttons` property to modals to allow user to specify additional buttons to show between the cancel and confirm buttons in the modal footer.
