### PR TITLE
Add two more test helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 
 [ember-img]: https://img.shields.io/badge/ember-1.12.2+-orange.svg "Ember 1.12.2+"
 
-[bithound-img]: https://www.bithound.io/github/ciena-blueplanet/ember-frost-modal/badges/score.svg "bitHound"
-[bithound-url]: https://www.bithound.io/github/ciena-blueplanet/ember-frost-modal
+[bithound-img]: https://www.bithound.io/github/ciena-frost/ember-frost-modal/badges/score.svg "bitHound"
+[bithound-url]: https://www.bithound.io/github/ciena-frost/ember-frost-modal
 
 # ember-frost-modal
 ###### Dependencies

--- a/test-support/helpers/ember-frost-modal.js
+++ b/test-support/helpers/ember-frost-modal.js
@@ -1,8 +1,18 @@
+/* global click */
+
 import {expect} from 'chai'
 import Ember from 'ember'
 const {$} = Ember
 
 const assign = Object.assign || Ember.assign || Ember.merge
+
+const selectors = {
+  cancelButton: '.frost-modal-dialog-footer-cancel-button',
+  confirmButton: '.frost-modal-dialog-footer-confirm-button',
+  dialog: '.frost-modal-dialog:visible',
+  subtitle: '.frost-modal-dialog-header-subtitle:visible',
+  title: '.frost-modal-dialog-header-title:visible'
+}
 
 /**
  * @typedef {Object} FrostModalButtonState
@@ -19,6 +29,22 @@ const assign = Object.assign || Ember.assign || Ember.merge
  * @property {String} title - title text
  * @property {Boolean} visible - whether or not modal should be visible
  */
+
+/**
+ * Click modal's cancel button
+ * @returns {RSVP.Promise} promise that resolves when all async behavior completes
+ */
+export function clickModalCancelButton () {
+  return click(selectors.cancelButton)
+}
+
+/**
+ * Click modal's confirm button
+ * @returns {RSVP.Promise} promise that resolves when all async behavior completes
+ */
+export function clickModalConfirmButton () {
+  return click(selectors.confirmButton)
+}
 
 /**
  * Verify button contains expected text
@@ -68,7 +94,7 @@ export function expectModalCancelButtonWithState (state = {}) {
     text: 'Cancel'
   }, state)
 
-  const $button = $('.frost-modal-dialog-footer-cancel-button')
+  const $button = $(selectors.cancelButton)
   expectButtonWithState($button, state)
 }
 
@@ -81,7 +107,7 @@ export function expectModalConfirmButtonWithState (state = {}) {
     text: 'Confirm'
   }, state)
 
-  const $button = $('.frost-modal-dialog-footer-confirm-button')
+  const $button = $(selectors.confirmButton)
   expectButtonWithState($button, state)
 }
 
@@ -119,7 +145,7 @@ export function expectModalWithState (state = {}) {
  * @param {String} text - expected subtitle text
  */
 export function expectModalWithSubtitle (text) {
-  const $subtitle = $('.frost-modal-dialog-header-subtitle:visible')
+  const $subtitle = $(selectors.subtitle)
   expect($subtitle.text().trim(), 'modal has expected subtitle').to.equal(text)
 }
 
@@ -128,7 +154,7 @@ export function expectModalWithSubtitle (text) {
  * @param {String} text - expected title text
  */
 export function expectModalWithTitle (text) {
-  const $title = $('.frost-modal-dialog-header-title:visible')
+  const $title = $(selectors.title)
     .clone().children().remove().end() // Remove subtitle DOM to get just the title
 
   expect($title.text().trim(), 'modal has expected title').to.equal(text)
@@ -141,11 +167,13 @@ export function expectModalWithTitle (text) {
 export function expectModalWithVisibility (visible = true) {
   const length = visible ? 1 : 0
   const message = visible ? 'modal is visible' : 'modal is not visible'
-  const $modals = $('.frost-modal-dialog:visible')
+  const $modals = $(selectors.dialog)
   expect($modals, message).to.have.length(length)
 }
 
 export default {
+  clickModalCancelButton,
+  clickModalConfirmButton,
   expectButtonToHaveText,
   expectButtonWithState,
   expectButtonWithVisibility,

--- a/tests/dummy/app/pods/demo/helpers/template.hbs
+++ b/tests/dummy/app/pods/demo/helpers/template.hbs
@@ -53,6 +53,26 @@
 
   <hr class="sep"/>
 
+  <h3><code>clickModalCancelButton ()</code></h3>
+  <p>Click modal's cancel button</p>
+  <h4>Returns:</h4>
+  <dl>
+    <dt>promise <span>RSVP.Promise</span></dt>
+    <dd>resolves when all async behavior completes</dd>
+  </dl>
+
+  <hr class="sep"/>
+
+  <h3><code>clickModalConfirmButton ()</code></h3>
+  <p>Click modal's confirm button</p>
+  <h4>Returns:</h4>
+  <dl>
+    <dt>promise <span>RSVP.Promise</span></dt>
+    <dd>resolves when all async behavior completes</dd>
+  </dl>
+
+  <hr class="sep"/>
+
   <h3><code>expectButtonToHaveText ($button, text)</code></h3>
   <p>Verify button contains expected text</p>
   <h4>Parameters:</h4>


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Resolves #29 
# CHANGELOG
- **Added** two more test helpers: `clickModalCancelButton()` and `clickModalConfirmButton()`.
- **Fixed** bithound.io badge in [README](README.md).
