### PR TITLE
Add more test helpers

### DIFF
--- a/test-support/helpers/ember-frost-modal.js
+++ b/test-support/helpers/ember-frost-modal.js
@@ -9,7 +9,14 @@ const assign = Object.assign || Ember.assign || Ember.merge
 const selectors = {
   cancelButton: '.frost-modal-dialog-footer-cancel-button',
   confirmButton: '.frost-modal-dialog-footer-confirm-button',
+  content: '.frost-modal-dialog-content',
   dialog: '.frost-modal-dialog:visible',
+  icons: {
+    confirm: '.frost-icon-frost-modal-warn',
+    error: '.frost-icon-frost-modal-error',
+    info: '.frost-icon-frost-modal-info',
+    warn: '.frost-icon-frost-modal-warn'
+  },
   subtitle: '.frost-modal-dialog-header-subtitle:visible',
   title: '.frost-modal-dialog-header-title:visible'
 }
@@ -25,6 +32,8 @@ const selectors = {
  * @typedef {Object} FrostModalState
  * @property {FrostModalButtonState} cancel - state of cancel button
  * @property {FrostModalButtonState} confirm - state of confirm button
+ * @property {String} content - content text
+ * @property {String} icon - icon type (confirm, error, info, or warn)
  * @property {String} subtitle - subtitle text
  * @property {String} title - title text
  * @property {Boolean} visible - whether or not modal should be visible
@@ -112,6 +121,24 @@ export function expectModalConfirmButtonWithState (state = {}) {
 }
 
 /**
+ * Verify modal content has expected text
+ * @param {String} text - expected content text
+ */
+export function expectModalWithContent (content) {
+  const $content = $(selectors.content)
+  expect($content.text().trim(), 'modal has expected content').to.equal(content)
+}
+
+/**
+ * Verify modal has expected icon
+ * @param {String} icon - expected icon (confirm, error, info, or warn)
+ */
+export function expectModalWithIcon (icon) {
+  const $content = $(selectors.icons[icon])
+  expect($content, 'modal has expected icon').to.have.length(1)
+}
+
+/**
  * Verify modal has correct state
  * @param {FrostModalState} [state={}] - expected state of modal
  */
@@ -128,12 +155,20 @@ export function expectModalWithState (state = {}) {
     return
   }
 
+  if ('icon' in state) {
+    expectModalWithIcon(state.icon)
+  }
+
   if ('title' in state) {
     expectModalWithTitle(state.title)
   }
 
   if ('subtitle' in state) {
     expectModalWithSubtitle(state.subtitle)
+  }
+
+  if ('content' in state) {
+    expectModalWithContent(state.content)
   }
 
   expectModalCancelButtonWithState(state.cancel)
@@ -179,6 +214,8 @@ export default {
   expectButtonWithVisibility,
   expectModalCancelButtonWithState,
   expectModalConfirmButtonWithState,
+  expectModalWithContent,
+  expectModalWithIcon,
   expectModalWithState,
   expectModalWithSubtitle,
   expectModalWithTitle,

--- a/test-support/helpers/ember-frost-modal.js
+++ b/test-support/helpers/ember-frost-modal.js
@@ -122,7 +122,7 @@ export function expectModalConfirmButtonWithState (state = {}) {
 
 /**
  * Verify modal content has expected text
- * @param {String} text - expected content text
+ * @param {String} content - expected content text
  */
 export function expectModalWithContent (content) {
   const $content = $(selectors.content)
@@ -138,6 +138,7 @@ export function expectModalWithIcon (icon) {
   expect($content, 'modal has expected icon').to.have.length(1)
 }
 
+/* eslint-disable complexity */
 /**
  * Verify modal has correct state
  * @param {FrostModalState} [state={}] - expected state of modal
@@ -174,6 +175,7 @@ export function expectModalWithState (state = {}) {
   expectModalCancelButtonWithState(state.cancel)
   expectModalConfirmButtonWithState(state.confirm)
 }
+/* eslint-enable complexity */
 
 /**
  * Verify modal subtitle has expected text

--- a/tests/dummy/app/pods/demo/helpers/template.hbs
+++ b/tests/dummy/app/pods/demo/helpers/template.hbs
@@ -39,6 +39,10 @@
     <dd>state of cancel button</dd>
     <dt>confirm <span>FrostModalButtonState</span></dt>
     <dd>state of confirm button</dd>
+    <dt>content <span>String</span></dt>
+    <dd>content text</dd>
+    <dt>icon <span>String</span></dt>
+    <dd>icon type (confirm, error, info, or warn)</dd>
     <dt>subtitle <span>String</span></dt>
     <dd>subtitle text</dd>
     <dt>title <span>String</span></dt>
@@ -127,6 +131,26 @@
   <dl>
     <dt>state <span>FrostModalButtonState</span></dt>
     <dd>expected state of confirm button</dd>
+  </dl>
+
+  <hr class="sep"/>
+
+  <h3><code>expectModalWithContent (content)</code></h3>
+  <p>Verify modal content has expected text</p>
+  <h4>Parameters:</h4>
+  <dl>
+    <dt>content <span>String</span></dt>
+    <dd>expected content text</dd>
+  </dl>
+
+  <hr class="sep"/>
+
+  <h3><code>expectModalWithIcon (icon)</code></h3>
+  <p>Verify modal has expected icon</p>
+  <h4>Parameters:</h4>
+  <dl>
+    <dt>icon <span>String</span></dt>
+    <dd>expected icon (confirm, error, info, or warn)</dd>
   </dl>
 
   <hr class="sep"/>


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Added** two new test helpers: `expectModalWithContent()` and `expectModalWithIcon()`.
- **Added** `icon` and `content` support to `expectModalWithState()` test helper.
