### PR TITLE
Add tests for enabled/disabled button state

### DIFF
--- a/test-support/helpers/ember-frost-modal.js
+++ b/test-support/helpers/ember-frost-modal.js
@@ -56,6 +56,22 @@ export function clickModalConfirmButton () {
 }
 
 /**
+ * Verify button is disabled
+ * @param {jQuery} $button - jQuery instance containing button
+ */
+export function expectButtonToBeDisabled ($button) {
+  expect($button.is(':disabled')).to.equal(true)
+}
+
+/**
+ * Verify button is enabled
+ * @param {jQuery} $button - jQuery instance containing button
+ */
+export function expectButtonToBeEnabled ($button) {
+  expect($button.is(':disabled')).to.equal(false)
+}
+
+/**
  * Verify button contains expected text
  * @param {jQuery} $button - jQuery instance containing button
  * @param {String} text - expected text
@@ -76,6 +92,12 @@ export function expectButtonWithState ($button, state) {
   }, state)
 
   expectButtonWithVisibility($button, state.visible, state.text)
+
+  if (state.disabled) {
+    expectButtonToBeDisabled($button)
+  } else {
+    expectButtonToBeEnabled($button)
+  }
 
   if (state.visible) {
     expectButtonToHaveText($button, state.text)
@@ -211,6 +233,8 @@ export function expectModalWithVisibility (visible = true) {
 export default {
   clickModalCancelButton,
   clickModalConfirmButton,
+  expectButtonToBeDisabled,
+  expectButtonToBeEnabled,
   expectButtonToHaveText,
   expectButtonWithState,
   expectButtonWithVisibility,

--- a/tests/dummy/app/pods/demo/helpers/template.hbs
+++ b/tests/dummy/app/pods/demo/helpers/template.hbs
@@ -77,6 +77,26 @@
 
   <hr class="sep"/>
 
+  <h3><code>expectButtonToBeDisabled ($button)</code></h3>
+  <p>Verify button is disabled</p>
+  <h4>Parameters:</h4>
+  <dl>
+    <dt>$button <span>jQuery</span></dt>
+    <dd>jQuery instance containing button</dd>
+  </dl>
+
+  <hr class="sep"/>
+
+  <h3><code>expectButtonToBeEnabled ($button)</code></h3>
+  <p>Verify button is enabled</p>
+  <h4>Parameters:</h4>
+  <dl>
+    <dt>$button <span>jQuery</span></dt>
+    <dd>jQuery instance containing button</dd>
+  </dl>
+
+  <hr class="sep"/>
+
   <h3><code>expectButtonToHaveText ($button, text)</code></h3>
   <p>Verify button contains expected text</p>
   <h4>Parameters:</h4>


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Added** two new test helpers `expectButtonToBeDisabled()` and `expectButtonToBeEnabled()`.
- **Fixed** test helper `expectButtonWithState()` to check disabled state.
