### PR TITLE
upgrade ember-prop-types for LTS support

### DIFF
--- a/addon/components/dialogs/about.js
+++ b/addon/components/dialogs/about.js
@@ -33,16 +33,12 @@ export default FrostModalBinding.extend(PropTypesMixin, {
   },
 
   getDefaultProps () {
-    let defaultProps = this._super()
-
-    assign(defaultProps, {
+    return {
       animation: about,
       classModifier: 'about',
       closeOnOutsideClick: true,
       modal: 'frost-modal-about-dialog'
-    })
-
-    return defaultProps
+    }
   },
 
   // == Computed properties ===================================================

--- a/addon/components/dialogs/form.js
+++ b/addon/components/dialogs/form.js
@@ -39,15 +39,11 @@ export default FrostModalBinding.extend(PropTypesMixin, {
   },
 
   getDefaultProps () {
-    let defaultProps = this._super()
-
-    assign(defaultProps, {
+    return {
       animation: form,
       classModifier: 'form',
       modal: 'frost-modal-dialog'
-    })
-
-    return defaultProps
+    }
   },
 
   // == Computed properties ===================================================

--- a/addon/components/dialogs/messages/confirm.js
+++ b/addon/components/dialogs/messages/confirm.js
@@ -42,15 +42,11 @@ export default FrostModalBinding.extend(PropTypesMixin, {
   },
 
   getDefaultProps () {
-    let defaultProps = this._super()
-
-    assign(defaultProps, {
+    return {
       animation: message,
       classModifier: 'message',
       modal: 'frost-modal-dialog'
-    })
-
-    return defaultProps
+    }
   },
 
   // == Computed properties ===================================================

--- a/addon/components/dialogs/messages/error.js
+++ b/addon/components/dialogs/messages/error.js
@@ -40,15 +40,11 @@ export default FrostModalBinding.extend(PropTypesMixin, {
   },
 
   getDefaultProps () {
-    let defaultProps = this._super()
-
-    assign(defaultProps, {
+    return {
       animation: message,
       classModifier: 'message',
       modal: 'frost-modal-dialog'
-    })
-
-    return defaultProps
+    }
   },
 
   // == Computed properties ===================================================

--- a/addon/components/dialogs/messages/info.js
+++ b/addon/components/dialogs/messages/info.js
@@ -40,15 +40,11 @@ export default FrostModalBinding.extend(PropTypesMixin, {
   },
 
   getDefaultProps () {
-    let defaultProps = this._super()
-
-    assign(defaultProps, {
+    return {
       animation: message,
       classModifier: 'message',
       modal: 'frost-modal-dialog'
-    })
-
-    return defaultProps
+    }
   },
 
   // == Computed properties ===================================================

--- a/addon/components/dialogs/messages/warn.js
+++ b/addon/components/dialogs/messages/warn.js
@@ -42,15 +42,11 @@ export default FrostModalBinding.extend(PropTypesMixin, {
   },
 
   getDefaultProps () {
-    let defaultProps = this._super()
-
-    assign(defaultProps, {
+    return {
       animation: message,
       classModifier: 'message',
       modal: 'frost-modal-dialog'
-    })
-
-    return defaultProps
+    }
   },
 
   // == Computed properties ===================================================

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "ember-moment": "7.0.0-beta.3",
     "ember-one-way-controls": "1.1.1",
     "ember-perfectscroll": "0.1.12",
-    "ember-prop-types": "2.5.4",
+    "ember-prop-types": "3.0.2",
     "ember-redux": "1.6.0",
     "ember-resolver": "^2.0.3",
     "ember-seamless-immutable-shim": "^1.0.1",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [x] #major# - incompatible API change
# CHANGELOG

_upgrade_ ember-prop-types to v3.x. Remove `this._super()` to support this. 
