### PR TITLE
add classmodifier to modal content

### DIFF
--- a/addon/components/dialogs/form.js
+++ b/addon/components/dialogs/form.js
@@ -43,7 +43,6 @@ export default FrostModalBinding.extend(PropTypesMixin, {
   getDefaultProps () {
     return {
       animation: form,
-      classModifier: 'form',
       modal: 'frost-modal-dialog'
     }
   },

--- a/addon/components/dialogs/form.js
+++ b/addon/components/dialogs/form.js
@@ -43,6 +43,7 @@ export default FrostModalBinding.extend(PropTypesMixin, {
   getDefaultProps () {
     return {
       animation: form,
+      classModifier: 'form',
       modal: 'frost-modal-dialog'
     }
   },

--- a/addon/templates/components/frost-modal-binding.hbs
+++ b/addon/templates/components/frost-modal-binding.hbs
@@ -4,6 +4,7 @@
     send=(hash
       animation=animation
       body=(component modal
+        classModifier=classModifier
         params=params
         hook=(concat hook '-modal')
         onCancel=(action '_onCancel')

--- a/tests/dummy/app/pods/demo/form/template.hbs
+++ b/tests/dummy/app/pods/demo/form/template.hbs
@@ -53,6 +53,7 @@
       text='Info'
     )
   )
+  classModifier='my-class'
   closeOnConfirm=false
   confirm=(hash
     disabled=(not isSomethingReady)

--- a/tests/integration/components/frost-modal-binding-test.js
+++ b/tests/integration/components/frost-modal-binding-test.js
@@ -35,6 +35,7 @@ describeComponent(
         }}
 
         {{frost-modal-binding 'basic-modal'
+          classModifier='custom-class'
           closeOnOutsideClick=true
           hook='basic'
           isVisible=isModalVisible
@@ -49,6 +50,13 @@ describeComponent(
       this.set('isModalVisible', true)
       expect($hook('basic-modal'), 'Modal becomes visible')
         .to.have.length(1)
+
+      expect(this.$('.frost-modal-outlet-background').hasClass('custom-class'),
+        'has class modifier').to.be.true
+      expect(this.$('.frost-modal-outlet-container').hasClass('custom-class'),
+        'has class modifier').to.be.true
+      expect(this.$('.frost-modal-outlet-body').hasClass('custom-class'),
+        'has class modifier').to.be.true
 
       $hook('basic-modal-confirm').click()
       expect($hook('basic-modal'), 'Modal is dismissed')


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
**adding** a classModifier for the contained modal.

