### PR TITLE
propagate visibility attr to custom buttons as well

### DIFF
--- a/addon/templates/components/frost-modal-dialog.hbs
+++ b/addon/templates/components/frost-modal-dialog.hbs
@@ -75,17 +75,19 @@
   }}
 
   {{#each params.buttons as |button index|}}
-    {{frost-button
-      disabled=button.disabled
-      hook=(concat hook '-button-' index)
-      icon=button.icon
-      pack=button.pack
-      priority=button.priority
-      size='medium'
-      onClick=button.onClick
-      tabIndex=(if button.tabIndex button.tabIndex 0)
-      text=button.text
-    }}
+    {{#if button.isVisible}}
+      {{frost-button
+        disabled=button.disabled
+        hook=(concat hook '-button-' index)
+        icon=button.icon
+        pack=button.pack
+        priority=button.priority
+        size='medium'
+        onClick=button.onClick
+        tabIndex=(if button.tabIndex button.tabIndex 0)
+        text=button.text
+      }}
+    {{/if}}
   {{/each}}
 
   {{frost-button

--- a/addon/templates/components/frost-modal-dialog.hbs
+++ b/addon/templates/components/frost-modal-dialog.hbs
@@ -75,11 +75,11 @@
   }}
 
   {{#each params.buttons as |button index|}}
-    {{#if button.isVisible}}
       {{frost-button
         disabled=button.disabled
         hook=(concat hook '-button-' index)
         icon=button.icon
+        isVisible=button.isVisible
         pack=button.pack
         priority=button.priority
         size='medium'
@@ -87,7 +87,6 @@
         tabIndex=(if button.tabIndex button.tabIndex 0)
         text=button.text
       }}
-    {{/if}}
   {{/each}}
 
   {{frost-button


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
**added** `isVisible` to any custom buttons 
