### PR TITLE
Update usage of deprecated ember-mocha describeComponent()

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "ember-sortable": "1.9.1",
     "ember-spread": "1.0.0",
     "ember-test-helpers": "0.5.34",
-    "ember-test-utils": "1.2.2",
+    "ember-test-utils": "^1.8.0",
     "ember-truth-helpers": "1.2.0",
     "ember-validator-shim": "~2.0.0",
     "ember-z-schema": "~2.0.0",

--- a/tests/integration/components/frost-modal-about-dialog-test.js
+++ b/tests/integration/components/frost-modal-about-dialog-test.js
@@ -1,190 +1,178 @@
-import {
-  expect
-} from 'chai'
-import {
-  $hook,
-  initialize
-} from 'ember-hook'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
-import { beforeEach } from 'mocha'
-import {
-  initialize as initializeSvgUse
-} from 'ember-frost-core/instance-initializers/svg-use-polyfill'
+import {expect} from 'chai'
+import {$hook, initialize} from 'ember-hook'
+import {beforeEach, describe, it} from 'mocha'
+import {initialize as initializeSvgUse} from 'ember-frost-core/instance-initializers/svg-use-polyfill'
 import hbs from 'htmlbars-inline-precompile'
 
-describeComponent(
-  'frost-modal-about-dialog',
-  'Integration: FrostModalAboutDialogComponent', {
-    integration: true
-  },
-  function () {
-    beforeEach(function () {
-      initialize()
-      initializeSvgUse()
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = integration('frost-modal-about-dialog')
+describe(test.label, function () {
+  test.setup()
+
+  beforeEach(function () {
+    initialize()
+    initializeSvgUse()
+  })
+
+  it('renders', function (done) {
+    this.timeout(10000)
+    this.set('closeModal', () => {
+      this.set('isModalVisible', false)
     })
+    this.set('isModalVisible', true)
 
-    it('renders', function (done) {
-      this.timeout(10000)
-      this.set('closeModal', () => {
-        this.set('isModalVisible', false)
-      })
-      this.set('isModalVisible', true)
+    this.render(hbs `
+      {{frost-modal-outlet}}
 
-      this.render(hbs `
-        {{frost-modal-outlet}}
+      {{frost-modal-about
+        brandingStrip=(hash
+          icon='company-strip'
+          pack='dummy'
+        )
+        copyright='copyright'
+        hook='about-dialog'
+        isVisible=isModalVisible
+        logo=(hash
+          icon='company'
+          pack='dummy'
+        )
+        product=(hash
+          icon='product'
+          pack='dummy'
+        )
+        versions=(array
+          'Version: 1.0.0'
+        )
+        onClose=(action closeModal)
+      }}
+    `)
+    // eslint-disable-next-line
+    expect($hook('about-dialog-modal'), 'Is modal visible')
+      .to.have.length(1)
 
-        {{frost-modal-about
-          brandingStrip=(hash
-            icon='company-strip'
-            pack='dummy'
-          )
-          copyright='copyright'
-          hook='about-dialog'
-          isVisible=isModalVisible
-          logo=(hash
-            icon='company'
-            pack='dummy'
-          )
-          product=(hash
-            icon='product'
-            pack='dummy'
-          )
-          versions=(array
-            'Version: 1.0.0'
-          )
-          onClose=(action closeModal)
-        }}
-      `)
-      // eslint-disable-next-line
-      expect($hook('about-dialog-modal'), 'Is modal visible')
-        .to.have.length(1)
-
-      return capture('about', done, {
-        targetElement: this.$('.frost-modal-outlet-container.about')[0],
-        experimentalSvgs: true
-      })
+    return capture('about', done, {
+      targetElement: this.$('.frost-modal-outlet-container.about')[0],
+      experimentalSvgs: true
     })
+  })
 
-    it('renders with product', function (done) {
-      this.timeout(10000)
-      this.set('closeModal', () => {
-        this.set('isModalVisible', false)
-      })
-      this.set('isModalVisible', true)
-
-      this.render(hbs `
-        {{frost-modal-outlet}}
-
-        {{frost-modal-about
-          brandingStrip=(hash
-            icon='company-strip'
-            pack='dummy'
-          )
-          copyright='copyright'
-          hook='about-dialog'
-          isVisible=isModalVisible
-          logo=(hash
-            icon='company'
-            pack='dummy'
-          )
-          product=(hash
-            icon='product'
-            pack='dummy'
-          )
-          onClose=(action closeModal)
-        }}
-      `)
-      // eslint-disable-next-line
-      expect($hook('about-dialog-modal'), 'Is modal visible')
-        .to.have.length(1)
-      return capture('about-with-product', done, {
-        targetElement: this.$('.frost-modal-outlet-container.about')[0],
-        experimentalSvgs: true
-      })
+  it('renders with product', function (done) {
+    this.timeout(10000)
+    this.set('closeModal', () => {
+      this.set('isModalVisible', false)
     })
+    this.set('isModalVisible', true)
 
-    it('renders about-with-multiple-versions', function (done) {
-      this.timeout(10000)
-      this.set('closeModal', () => {
-        this.set('isModalVisible', false)
-      })
-      this.set('isModalVisible', true)
+    this.render(hbs `
+      {{frost-modal-outlet}}
 
-      this.render(hbs `
-        {{frost-modal-outlet}}
-
-        {{frost-modal-about
-          brandingStrip=(hash
-            icon='company-strip'
-            pack='dummy'
-          )
-          copyright='copyright'
-          hook='about-dialog'
-          isVisible=isModalVisible
-          logo=(hash
-            icon='company'
-            pack='dummy'
-          )
-          versions=(array
-            'Version: 1.0.0' 'Version: 2.3.4'
-          )
-          onClose=(action closeModal)
-        }}
-      `)
-      // eslint-disable-next-line
-      expect($hook('about-dialog-modal'), 'Is modal visible')
-        .to.have.length(1)
-      return capture('about-with-multiple-verions', done, {
-        targetElement: this.$('.frost-modal-outlet-container.about')[0],
-        experimentalSvgs: true
-      })
+      {{frost-modal-about
+        brandingStrip=(hash
+          icon='company-strip'
+          pack='dummy'
+        )
+        copyright='copyright'
+        hook='about-dialog'
+        isVisible=isModalVisible
+        logo=(hash
+          icon='company'
+          pack='dummy'
+        )
+        product=(hash
+          icon='product'
+          pack='dummy'
+        )
+        onClose=(action closeModal)
+      }}
+    `)
+    // eslint-disable-next-line
+    expect($hook('about-dialog-modal'), 'Is modal visible')
+      .to.have.length(1)
+    return capture('about-with-product', done, {
+      targetElement: this.$('.frost-modal-outlet-container.about')[0],
+      experimentalSvgs: true
     })
+  })
 
-    it('renders about-with-product-and-multiple-versions', function (done) {
-      this.timeout(10000)
-      this.set('closeModal', () => {
-        this.set('isModalVisible', false)
-      })
-      this.set('isModalVisible', true)
-
-      this.render(hbs `
-        {{frost-modal-outlet}}
-
-        {{frost-modal-about
-          brandingStrip=(hash
-            icon='company-strip'
-            pack='dummy'
-          )
-          copyright='copyright'
-          hook='about-dialog'
-          isVisible=isModalVisible
-          logo=(hash
-            icon='company'
-            pack='dummy'
-          )
-          product=(hash
-            icon='product'
-            pack='dummy'
-          )
-          versions=(array
-            'Version: 1.0.0' 'Version: 2.3.4'
-          )
-          onClose=(action closeModal)
-        }}
-      `)
-      // eslint-disable-next-line
-      expect($hook('about-dialog-modal'), 'Is modal visible')
-        .to.have.length(1)
-      return capture('about-with-product-and-multiple-verions', done, {
-        targetElement: this.$('.frost-modal-outlet-container.about')[0],
-        experimentalSvgs: true
-      })
+  it('renders about-with-multiple-versions', function (done) {
+    this.timeout(10000)
+    this.set('closeModal', () => {
+      this.set('isModalVisible', false)
     })
-  }
-)
+    this.set('isModalVisible', true)
+
+    this.render(hbs `
+      {{frost-modal-outlet}}
+
+      {{frost-modal-about
+        brandingStrip=(hash
+          icon='company-strip'
+          pack='dummy'
+        )
+        copyright='copyright'
+        hook='about-dialog'
+        isVisible=isModalVisible
+        logo=(hash
+          icon='company'
+          pack='dummy'
+        )
+        versions=(array
+          'Version: 1.0.0' 'Version: 2.3.4'
+        )
+        onClose=(action closeModal)
+      }}
+    `)
+    // eslint-disable-next-line
+    expect($hook('about-dialog-modal'), 'Is modal visible')
+      .to.have.length(1)
+    return capture('about-with-multiple-verions', done, {
+      targetElement: this.$('.frost-modal-outlet-container.about')[0],
+      experimentalSvgs: true
+    })
+  })
+
+  it('renders about-with-product-and-multiple-versions', function (done) {
+    this.timeout(10000)
+    this.set('closeModal', () => {
+      this.set('isModalVisible', false)
+    })
+    this.set('isModalVisible', true)
+
+    this.render(hbs `
+      {{frost-modal-outlet}}
+
+      {{frost-modal-about
+        brandingStrip=(hash
+          icon='company-strip'
+          pack='dummy'
+        )
+        copyright='copyright'
+        hook='about-dialog'
+        isVisible=isModalVisible
+        logo=(hash
+          icon='company'
+          pack='dummy'
+        )
+        product=(hash
+          icon='product'
+          pack='dummy'
+        )
+        versions=(array
+          'Version: 1.0.0' 'Version: 2.3.4'
+        )
+        onClose=(action closeModal)
+      }}
+    `)
+    // eslint-disable-next-line
+    expect($hook('about-dialog-modal'), 'Is modal visible')
+      .to.have.length(1)
+    return capture('about-with-product-and-multiple-verions', done, {
+      targetElement: this.$('.frost-modal-outlet-container.about')[0],
+      experimentalSvgs: true
+    })
+  })
+})
 
 // data-test={{hook (concat hook '-close')}}
 // onclick={{action (action onClose)}}

--- a/tests/integration/components/frost-modal-about-test.js
+++ b/tests/integration/components/frost-modal-about-test.js
@@ -1,67 +1,58 @@
-import { expect } from 'chai'
-import {
-  $hook,
-  initialize
-} from 'ember-hook'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
-import { beforeEach } from 'mocha'
+import {expect} from 'chai'
+import {$hook, initialize} from 'ember-hook'
+import {beforeEach, describe, it} from 'mocha'
 import hbs from 'htmlbars-inline-precompile'
 
-describeComponent(
-  'frost-modal-about',
-  'Integration: FrostModalAboutComponent',
-  {
-    integration: true
-  },
-  function () {
-    beforeEach(function () {
-      initialize()
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = integration('frost-modal-about')
+describe(test.label, function () {
+  test.setup()
+
+  beforeEach(function () {
+    initialize()
+  })
+
+  it('renders', function () {
+    this.set('actions', {
+      closeModal () {
+        this.set('isModalVisible', false)
+      }
     })
+    this.set('isModalVisible', true)
 
-    it('renders', function () {
-      this.set('actions', {
-        closeModal () {
-          this.set('isModalVisible', false)
-        }
-      })
-      this.set('isModalVisible', true)
+    this.render(hbs`
+      {{frost-modal-outlet}}
 
-      this.render(hbs`
-        {{frost-modal-outlet}}
+      {{frost-modal-about
+        brandingStrip=(hash
+          icon='company-strip'
+          pack='dummy'
+        )
+        copyright='copyright'
+        hook='about-dialog'
+        isVisible=isModalVisible
+        logo=(hash
+          icon='company'
+          pack='dummy'
+        )
+        product=(hash
+          icon='product'
+          pack='dummy'
+        )
+        versions=(array
+          'Version: 1.0.0'
+        )
+        onClose=(action 'closeModal')
+      }}
+    `)
 
-        {{frost-modal-about
-          brandingStrip=(hash
-            icon='company-strip'
-            pack='dummy'
-          )
-          copyright='copyright'
-          hook='about-dialog'
-          isVisible=isModalVisible
-          logo=(hash
-            icon='company'
-            pack='dummy'
-          )
-          product=(hash
-            icon='product'
-            pack='dummy'
-          )
-          versions=(array
-            'Version: 1.0.0'
-          )
-          onClose=(action 'closeModal')
-        }}
-      `)
+    expect($hook('about-dialog-modal'), 'Is modal visible')
+      .to.have.length(1)
 
-      expect($hook('about-dialog-modal'), 'Is modal visible')
-        .to.have.length(1)
+    $hook('about-dialog-modal-close').click()
 
-      $hook('about-dialog-modal-close').click()
-
-      expect($hook('about-dialog-modal'), 'Is modal hidden')
-        .to.have.length(0)
-    })
-  }
-)
+    expect($hook('about-dialog-modal'), 'Is modal hidden')
+      .to.have.length(0)
+  })
+})

--- a/tests/integration/components/frost-modal-binding-test.js
+++ b/tests/integration/components/frost-modal-binding-test.js
@@ -1,66 +1,57 @@
-import { expect } from 'chai'
-import {
-  $hook,
-  initialize
-} from 'ember-hook'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
-import { beforeEach } from 'mocha'
+import {expect} from 'chai'
+import {$hook, initialize} from 'ember-hook'
+import {beforeEach, describe, it} from 'mocha'
 import hbs from 'htmlbars-inline-precompile'
 
-describeComponent(
-  'frost-modal-binding',
-  'Integration: FrostModalBindingComponent',
-  {
-    integration: true
-  },
-  function () {
-    beforeEach(function () {
-      initialize()
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = integration('frost-modal-binding')
+describe(test.label, function () {
+  test.setup()
+
+  beforeEach(function () {
+    initialize()
+  })
+
+  it('renders', function () {
+    this.set('isModalVisible', false)
+    this.set('actions', {
+      closeModal () {
+        this.set('isModalVisible', false)
+      }
     })
 
-    it('renders', function () {
-      this.set('isModalVisible', false)
-      this.set('actions', {
-        closeModal () {
-          this.set('isModalVisible', false)
-        }
-      })
+    this.render(hbs`
+      {{frost-modal-outlet
+        name='basic'
+      }}
 
-      this.render(hbs`
-        {{frost-modal-outlet
-          name='basic'
-        }}
+      {{frost-modal-binding 'basic-modal'
+        classModifier='custom-class'
+        closeOnOutsideClick=true
+        hook='basic'
+        isVisible=isModalVisible
+        targetOutlet='basic'
+        onClose=(action 'closeModal')
+      }}
+    `)
 
-        {{frost-modal-binding 'basic-modal'
-          classModifier='custom-class'
-          closeOnOutsideClick=true
-          hook='basic'
-          isVisible=isModalVisible
-          targetOutlet='basic'
-          onClose=(action 'closeModal')
-        }}
-      `)
+    expect($hook('basic-modal'), 'Modal is initially hidden')
+      .to.have.length(0)
 
-      expect($hook('basic-modal'), 'Modal is initially hidden')
-        .to.have.length(0)
+    this.set('isModalVisible', true)
+    expect($hook('basic-modal'), 'Modal becomes visible')
+      .to.have.length(1)
 
-      this.set('isModalVisible', true)
-      expect($hook('basic-modal'), 'Modal becomes visible')
-        .to.have.length(1)
+    expect(this.$('.frost-modal-outlet-background').hasClass('custom-class'),
+      'has class modifier').to.be.true
+    expect(this.$('.frost-modal-outlet-container').hasClass('custom-class'),
+      'has class modifier').to.be.true
+    expect(this.$('.frost-modal-outlet-body').hasClass('custom-class'),
+      'has class modifier').to.be.true
 
-      expect(this.$('.frost-modal-outlet-background').hasClass('custom-class'),
-        'has class modifier').to.be.true
-      expect(this.$('.frost-modal-outlet-container').hasClass('custom-class'),
-        'has class modifier').to.be.true
-      expect(this.$('.frost-modal-outlet-body').hasClass('custom-class'),
-        'has class modifier').to.be.true
-
-      $hook('basic-modal-confirm').click()
-      expect($hook('basic-modal'), 'Modal is dismissed')
-        .to.have.length(0)
-    })
-  }
-)
+    $hook('basic-modal-confirm').click()
+    expect($hook('basic-modal'), 'Modal is dismissed')
+      .to.have.length(0)
+  })
+})

--- a/tests/integration/components/frost-modal-confirm-message-test.js
+++ b/tests/integration/components/frost-modal-confirm-message-test.js
@@ -1,99 +1,91 @@
 import {expect} from 'chai'
-
-import {
-  initialize as initializeSvgUse
-} from 'ember-frost-core/instance-initializers/svg-use-polyfill'
-
+import {initialize as initializeSvgUse} from 'ember-frost-core/instance-initializers/svg-use-polyfill'
 import {$hook, initialize as initializeHook} from 'ember-hook'
-import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe} from 'mocha'
+import {beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
 import {expectModalWithState} from 'dummy/tests/helpers/ember-frost-modal'
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-describeComponent(
-  'frost-modal-confirm-message',
-  'Integration: FrostModalConfirmMessageComponent',
-  {
-    integration: true
-  },
-  function () {
+const test = integration('frost-modal-confirm-message')
+describe(test.label, function () {
+  test.setup()
+
+  beforeEach(function () {
+    initializeHook()
+    initializeSvgUse()
+  })
+
+  describe('render visible confirm modal', function () {
+    let props
+
     beforeEach(function () {
-      initializeHook()
-      initializeSvgUse()
+      this.timeout(10000)
+
+      this.set('closeModal', () => {
+        this.set('isModalVisible', false)
+      })
+
+      props = {
+        hook: 'confirm-dialog',
+        isModalVisible: true,
+        onConfirm: sinon.spy()
+      }
+
+      this.setProperties(props)
+
+      this.render(hbs`
+        {{frost-modal-outlet}}
+
+        {{frost-modal-confirm-message
+        hook=hook
+        cancel=(hash
+          isVisible=false
+        )
+        confirm=(hash
+          text='100%'
+        )
+        isVisible=isModalVisible
+        summary='I agree'
+        title='Most definitely'
+        onConfirm=onConfirm
+        onClose=(action closeModal)
+      }}`)
     })
 
-    describe('render visible confirm modal', function () {
-      let props
+    it('renders visually as expected', function (done) {
+      return capture('confirm', done, {
+        targetElement: this.$('.frost-modal-outlet-container.message')[0],
+        experimentalSvgs: true
+      })
+    })
 
+    it('renders as expected', function () {
+      expectModalWithState({
+        cancel: {
+          visible: false
+        },
+        confirm: {
+          text: '100%'
+        },
+        summary: 'I agree',
+        title: 'Most definitely'
+      })
+    })
+
+    describe('press confirm button', function () {
       beforeEach(function () {
-        this.timeout(10000)
-
-        this.set('closeModal', () => {
-          this.set('isModalVisible', false)
-        })
-
-        props = {
-          hook: 'confirm-dialog',
-          isModalVisible: true,
-          onConfirm: sinon.spy()
-        }
-
-        this.setProperties(props)
-
-        this.render(hbs`
-          {{frost-modal-outlet}}
-
-          {{frost-modal-confirm-message
-          hook=hook
-          cancel=(hash
-            isVisible=false
-          )
-          confirm=(hash
-            text='100%'
-          )
-          isVisible=isModalVisible
-          summary='I agree'
-          title='Most definitely'
-          onConfirm=onConfirm
-          onClose=(action closeModal)
-        }}`)
+        $hook('confirm-dialog-modal-confirm').click()
       })
 
-      it('renders visually as expected', function (done) {
-        return capture('confirm', done, {
-          targetElement: this.$('.frost-modal-outlet-container.message')[0],
-          experimentalSvgs: true
-        })
+      it('triggers the callback', function () {
+        expect(props.onConfirm.called).to.equal(true)
       })
 
-      it('renders as expected', function () {
-        expectModalWithState({
-          cancel: {
-            visible: false
-          },
-          confirm: {
-            text: '100%'
-          },
-          summary: 'I agree',
-          title: 'Most definitely'
-        })
-      })
-
-      describe('press confirm button', function () {
-        beforeEach(function () {
-          $hook('confirm-dialog-modal-confirm').click()
-        })
-
-        it('triggers the callback', function () {
-          expect(props.onConfirm.called).to.equal(true)
-        })
-
-        it('closes', function () {
-          expect($hook('confirm-dialog-modal')).to.have.length(0)
-        })
+      it('closes', function () {
+        expect($hook('confirm-dialog-modal')).to.have.length(0)
       })
     })
-  }
-)
+  })
+})

--- a/tests/integration/components/frost-modal-dialog-test.js
+++ b/tests/integration/components/frost-modal-dialog-test.js
@@ -1,29 +1,24 @@
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-modal-dialog',
-  'Integration: FrostModalDialogComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders', function () {
-      // Set any properties with this.set('myProperty', 'value');
-      // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#frost-modal-dialog}}
-      //     template content
-      //   {{/frost-modal-dialog}}
-      // `);
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.render(hbs`{{frost-modal-dialog}}`)
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+const test = integration('frost-modal-dialog')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#frost-modal-dialog}}
+    //     template content
+    //   {{/frost-modal-dialog}}
+    // `);
+
+    this.render(hbs`{{frost-modal-dialog}}`)
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/integration/components/frost-modal-error-message-test.js
+++ b/tests/integration/components/frost-modal-error-message-test.js
@@ -1,141 +1,132 @@
+import {expect} from 'chai'
 import Ember from 'ember'
-const { A } = Ember
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+const {A} = Ember
 import hbs from 'htmlbars-inline-precompile'
-import {
-  $hook,
-  initialize as initializeHook
-} from 'ember-hook'
-import { beforeEach, describe } from 'mocha'
+import {$hook, initialize as initializeHook} from 'ember-hook'
+import {beforeEach, describe, it} from 'mocha'
 
-describeComponent(
-  'frost-modal-error-message',
-  'Integration: FrostModalErrorMessageComponent',
-  {
-    integration: true
-  },
-  function () {
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = integration('frost-modal-error-message')
+describe(test.label, function () {
+  test.setup()
+
+  beforeEach(function () {
+    initializeHook()
+    this.timeout(10000)
+    this.set('closeModal', () => {
+      this.set('isModalVisible', false)
+    })
+    this.set('things', A([]))
+    const things = this.get('things')
+    while (this.get('things').length < 50) {
+      things.addObject(`Thing ${things.length + 1}`)
+    }
+    this.set('isModalVisible', true)
+
+    this.render(hbs`
+      {{frost-modal-outlet}}
+      {{frost-modal-error-message
+        buttons=buttons
+        confirm=(hash
+          isVisible=false
+        )
+        details=(component 'list-em' things=things)
+        footer=footer
+        hook='error-dialog'
+        isVisible=isModalVisible
+        subtitle=subtitle
+        summary='Are you familiar with the old robot saying?'
+        title='"Does not compute"'
+        onClose=(action closeModal)
+      }}`
+    )
+  })
+
+  it('renders', function (done) {
+    return capture('error-dialog', done, {
+      targetElement: this.$('.frost-modal-outlet-container.message')[0],
+      experimentalSvgs: true
+    })
+  })
+
+  it('closes on cancel', function () {
+    $hook('error-dialog-modal-cancel').click()
+
+    expect($hook('error-dialog-modal'), 'Is modal hidden')
+        .to.have.length(0)
+  })
+
+  describe('when subtitle present', function () {
     beforeEach(function () {
-      initializeHook()
-      this.timeout(10000)
-      this.set('closeModal', () => {
-        this.set('isModalVisible', false)
-      })
-      this.set('things', A([]))
-      const things = this.get('things')
-      while (this.get('things').length < 50) {
-        things.addObject(`Thing ${things.length + 1}`)
-      }
-      this.set('isModalVisible', true)
-
-      this.render(hbs`
-        {{frost-modal-outlet}}
-        {{frost-modal-error-message
-          buttons=buttons
-          confirm=(hash
-            isVisible=false
-          )
-          details=(component 'list-em' things=things)
-          footer=footer
-          hook='error-dialog'
-          isVisible=isModalVisible
-          subtitle=subtitle
-          summary='Are you familiar with the old robot saying?'
-          title='"Does not compute"'
-          onClose=(action closeModal)
-        }}`
-      )
+      this.set('subtitle', 'Foo bar')
     })
 
-    it('renders', function (done) {
-      return capture('error-dialog', done, {
-        targetElement: this.$('.frost-modal-outlet-container.message')[0],
-        experimentalSvgs: true
-      })
+    it('renders subtitle', function () {
+      const $subtitle = this.$('.frost-modal-dialog-header-subtitle')
+      expect($subtitle).to.have.length(1)
+      expect($subtitle.text()).to.equal('Foo bar')
+    })
+  })
+
+  describe('when subtitle not present', function () {
+    beforeEach(function () {
+      this.set('subtitle', undefined)
     })
 
-    it('closes on cancel', function () {
-      $hook('error-dialog-modal-cancel').click()
+    it('does not render subtitle DOM', function () {
+      expect(this.$('.frost-modal-dialog-header-subtitle')).to.have.length(0)
+    })
+  })
 
-      expect($hook('error-dialog-modal'), 'Is modal hidden')
-          .to.have.length(0)
+  describe('when footer text present', function () {
+    beforeEach(function () {
+      this.set('footer', 'Foo bar')
     })
 
-    describe('when subtitle present', function () {
-      beforeEach(function () {
-        this.set('subtitle', 'Foo bar')
-      })
+    it('renders footer text', function () {
+      const $footer = this.$('.frost-modal-dialog-footer-content')
+      expect($footer).to.have.length(1)
+      expect($footer.text().trim()).to.equal('Foo bar')
+    })
+  })
 
-      it('renders subtitle', function () {
-        const $subtitle = this.$('.frost-modal-dialog-header-subtitle')
-        expect($subtitle).to.have.length(1)
-        expect($subtitle.text()).to.equal('Foo bar')
-      })
+  describe('when footer text not present', function () {
+    beforeEach(function () {
+      this.set('footer', undefined)
     })
 
-    describe('when subtitle not present', function () {
-      beforeEach(function () {
-        this.set('subtitle', undefined)
-      })
+    it('does not render footer text DOM', function () {
+      expect(this.$('.frost-modal-dialog-footer-content')).to.have.length(0)
+    })
+  })
 
-      it('does not render subtitle DOM', function () {
-        expect(this.$('.frost-modal-dialog-header-subtitle')).to.have.length(0)
-      })
+  describe('when buttons present', function () {
+    beforeEach(function () {
+      this.set('buttons', [
+        {
+          priority: 'secondary',
+          text: 'Foo'
+        },
+        {
+          priority: 'secondary',
+          text: 'Bar'
+        }
+      ])
     })
 
-    describe('when footer text present', function () {
-      beforeEach(function () {
-        this.set('footer', 'Foo bar')
-      })
+    it('renders custom buttons plus cancel and create buttons', function () {
+      expect(this.$('.frost-modal-dialog-footer button')).to.have.length(4)
+    })
+  })
 
-      it('renders footer text', function () {
-        const $footer = this.$('.frost-modal-dialog-footer-content')
-        expect($footer).to.have.length(1)
-        expect($footer.text().trim()).to.equal('Foo bar')
-      })
+  describe('when buttons not present', function () {
+    beforeEach(function () {
+      this.set('buttons', undefined)
     })
 
-    describe('when footer text not present', function () {
-      beforeEach(function () {
-        this.set('footer', undefined)
-      })
-
-      it('does not render footer text DOM', function () {
-        expect(this.$('.frost-modal-dialog-footer-content')).to.have.length(0)
-      })
+    it('only renders cancel and create buttons', function () {
+      expect(this.$('.frost-modal-dialog-footer button')).to.have.length(2)
     })
-
-    describe('when buttons present', function () {
-      beforeEach(function () {
-        this.set('buttons', [
-          {
-            priority: 'secondary',
-            text: 'Foo'
-          },
-          {
-            priority: 'secondary',
-            text: 'Bar'
-          }
-        ])
-      })
-
-      it('renders custom buttons plus cancel and create buttons', function () {
-        expect(this.$('.frost-modal-dialog-footer button')).to.have.length(4)
-      })
-    })
-
-    describe('when buttons not present', function () {
-      beforeEach(function () {
-        this.set('buttons', undefined)
-      })
-
-      it('only renders cancel and create buttons', function () {
-        expect(this.$('.frost-modal-dialog-footer button')).to.have.length(2)
-      })
-    })
-  }
-)
+  })
+})

--- a/tests/integration/components/frost-modal-form-test.js
+++ b/tests/integration/components/frost-modal-form-test.js
@@ -1,257 +1,248 @@
+import {expect} from 'chai'
 import Ember from 'ember'
-const { run } = Ember
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+const {run} = Ember
 import hbs from 'htmlbars-inline-precompile'
-import {
-  $hook,
-  initialize as initializeHook
-} from 'ember-hook'
-import { beforeEach, describe } from 'mocha'
+import {$hook, initialize as initializeHook} from 'ember-hook'
+import {beforeEach, describe, it} from 'mocha'
 
-describeComponent(
-  'frost-modal-form',
-  'Integration: FrostModalFormComponent',
-  {
-    integration: true
-  },
-  function () {
-    let props
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-    beforeEach(function () {
-      initializeHook()
-      this.timeout(10000)
-      this.set('closeModal', () => {
-        this.set('isFormVisible', false)
-      })
-      props = {
-        closeOnConfirm: true,
-        hook: 'form-dialog',
-        isFormVisible: true,
-        simpleBunsenChange: sinon.spy(),
-        simpleBunsenModel: {
-          type: 'object',
-          properties: {
-            firstName: {
-              type: 'string'
-            },
-            lastName: {
-              type: 'string'
-            },
-            alias: {
-              type: 'string',
-              title: 'Nickname'
-            },
-            onlyChild: {
-              type: 'boolean'
-            },
-            age: {
-              type: 'number',
-              title: 'Age'
-            }
+const test = integration('frost-modal-form')
+describe(test.label, function () {
+  test.setup()
+
+  let props
+
+  beforeEach(function () {
+    initializeHook()
+    this.timeout(10000)
+    this.set('closeModal', () => {
+      this.set('isFormVisible', false)
+    })
+    props = {
+      closeOnConfirm: true,
+      hook: 'form-dialog',
+      isFormVisible: true,
+      simpleBunsenChange: sinon.spy(),
+      simpleBunsenModel: {
+        type: 'object',
+        properties: {
+          firstName: {
+            type: 'string'
           },
-          required: ['lastName']
+          lastName: {
+            type: 'string'
+          },
+          alias: {
+            type: 'string',
+            title: 'Nickname'
+          },
+          onlyChild: {
+            type: 'boolean'
+          },
+          age: {
+            type: 'number',
+            title: 'Age'
+          }
         },
-        simpleBunsenValue: {},
-        onConfirm: sinon.spy()
-      }
-      run(() => {
-        this.setProperties(props)
-        this.render(hbs`
-          {{frost-modal-outlet}}
+        required: ['lastName']
+      },
+      simpleBunsenValue: {},
+      onConfirm: sinon.spy()
+    }
+    run(() => {
+      this.setProperties(props)
+      this.render(hbs`
+        {{frost-modal-outlet}}
 
-          {{frost-modal-form
-            buttons=buttons
-            cancel=cancel
-            closeOnConfirm=closeOnConfirm
-            confirm=confirm
-            footer=footer
-            form=(component 'frost-bunsen-form'
-              bunsenModel=simpleBunsenModel
-              hook='bunsen-form'
-              onChange=simpleBunsenChange
-              value=simpleBunsenValue
-            )
-            hook='form-dialog'
-            isVisible=isFormVisible
-            subtitle=subtitle
-            title='Easy peasy'
-            onClose=(action closeModal)
-            onConfirm=onConfirm
-          }}
-        `)
+        {{frost-modal-form
+          buttons=buttons
+          cancel=cancel
+          closeOnConfirm=closeOnConfirm
+          confirm=confirm
+          footer=footer
+          form=(component 'frost-bunsen-form'
+            bunsenModel=simpleBunsenModel
+            hook='bunsen-form'
+            onChange=simpleBunsenChange
+            value=simpleBunsenValue
+          )
+          hook='form-dialog'
+          isVisible=isFormVisible
+          subtitle=subtitle
+          title='Easy peasy'
+          onClose=(action closeModal)
+          onConfirm=onConfirm
+        }}
+      `)
+    })
+  })
+
+  it('renders', function () {
+    expect($hook('form-dialog-modal')).to.have.length(1)
+  })
+
+  it('closes on cancel', function () {
+    $hook('form-dialog-modal-cancel').click()
+    expect($hook('form-dialog-modal'), 'Is modal hidden').to.have.length(0)
+  })
+
+  it('triggers function on confirm click', function () {
+    $hook('form-dialog-modal-confirm').click()
+    expect(props.onConfirm.called, 'Is confirm called').to.be.true
+  })
+
+  it('closes on confirm when closeOnConfirm=true', function () {
+    $hook('form-dialog-modal-confirm').click()
+    expect($hook('form-dialog-modal'), 'Is modal hidden').to.have.length(0)
+  })
+
+  it('should have confirm button with tabIndex === 0', function () {
+    expect($hook('form-dialog-modal-confirm').prop('tabindex')).to.equal(0)
+  })
+
+  it('should have cancel button with tabIndex === 1', function () {
+    expect($hook('form-dialog-modal-cancel').prop('tabindex')).to.equal(1)
+  })
+
+  describe('when cancel is given tabIndex: 0', function () {
+    beforeEach(function () {
+      this.set('cancel', {
+        tabIndex: 0
       })
     })
 
-    it('renders', function () {
-      expect($hook('form-dialog-modal')).to.have.length(1)
+    it('should have cancel button with tabIndex === 0', function () {
+      expect($hook('form-dialog-modal-cancel').prop('tabindex')).to.equal(0)
+    })
+  })
+
+  describe('when confirm is given tabIndex: 1', function () {
+    beforeEach(function () {
+      this.set('confirm', {
+        tabIndex: 1
+      })
     })
 
-    it('closes on cancel', function () {
-      $hook('form-dialog-modal-cancel').click()
-      expect($hook('form-dialog-modal'), 'Is modal hidden').to.have.length(0)
+    it('should have confirm button with tabIndex === 1', function () {
+      expect($hook('form-dialog-modal-confirm').prop('tabindex')).to.equal(1)
+    })
+  })
+
+  describe('when closeOnConfirm is false', function () {
+    beforeEach(function () {
+      this.set('closeOnConfirm', false)
     })
 
-    it('triggers function on confirm click', function () {
+    it('stays open', function () {
       $hook('form-dialog-modal-confirm').click()
-      expect(props.onConfirm.called, 'Is confirm called').to.be.true
+      expect($hook('form-dialog-modal'), 'Is modal hidden').to.have.length(1)
+    })
+  })
+
+  describe('when subtitle present', function () {
+    beforeEach(function () {
+      this.set('subtitle', 'Foo bar')
     })
 
-    it('closes on confirm when closeOnConfirm=true', function () {
-      $hook('form-dialog-modal-confirm').click()
-      expect($hook('form-dialog-modal'), 'Is modal hidden').to.have.length(0)
+    it('renders subtitle', function () {
+      const $subtitle = this.$('.frost-modal-dialog-header-subtitle')
+      expect($subtitle).to.have.length(1)
+      expect($subtitle.text()).to.equal('Foo bar')
+    })
+  })
+
+  describe('when subtitle not present', function () {
+    beforeEach(function () {
+      this.set('subtitle', undefined)
     })
 
-    it('should have confirm button with tabIndex === 0', function () {
-      expect($hook('form-dialog-modal-confirm').prop('tabindex')).to.equal(0)
+    it('does not render subtitle DOM', function () {
+      expect(this.$('.frost-modal-dialog-header-subtitle')).to.have.length(0)
+    })
+  })
+
+  describe('when footer text present', function () {
+    beforeEach(function () {
+      this.set('footer', 'Foo bar')
     })
 
-    it('should have cancel button with tabIndex === 1', function () {
-      expect($hook('form-dialog-modal-cancel').prop('tabindex')).to.equal(1)
+    it('renders footer text', function () {
+      const $footer = this.$('.frost-modal-dialog-footer-content')
+      expect($footer).to.have.length(1)
+      expect($footer.text().trim()).to.equal('Foo bar')
+    })
+  })
+
+  describe('when footer text not present', function () {
+    beforeEach(function () {
+      this.set('footer', undefined)
     })
 
-    describe('when cancel is given tabIndex: 0', function () {
-      beforeEach(function () {
-        this.set('cancel', {
-          tabIndex: 0
-        })
-      })
+    it('does not render footer text DOM', function () {
+      expect(this.$('.frost-modal-dialog-footer-content')).to.have.length(0)
+    })
+  })
 
-      it('should have cancel button with tabIndex === 0', function () {
-        expect($hook('form-dialog-modal-cancel').prop('tabindex')).to.equal(0)
-      })
+  describe('when buttons present', function () {
+    beforeEach(function () {
+      this.set('buttons', [
+        {
+          priority: 'secondary',
+          text: 'Foo'
+        },
+        {
+          priority: 'secondary',
+          text: 'Bar'
+        }
+      ])
     })
 
-    describe('when confirm is given tabIndex: 1', function () {
-      beforeEach(function () {
-        this.set('confirm', {
-          tabIndex: 1
-        })
-      })
-
-      it('should have confirm button with tabIndex === 1', function () {
-        expect($hook('form-dialog-modal-confirm').prop('tabindex')).to.equal(1)
-      })
+    it('renders custom buttons plus cancel and create buttons', function () {
+      expect(this.$('.frost-modal-dialog-footer button')).to.have.length(4)
     })
 
-    describe('when closeOnConfirm is false', function () {
-      beforeEach(function () {
-        this.set('closeOnConfirm', false)
-      })
-
-      it('stays open', function () {
-        $hook('form-dialog-modal-confirm').click()
-        expect($hook('form-dialog-modal'), 'Is modal hidden').to.have.length(1)
-      })
+    it('should have first button with tabIndex of 0', function () {
+      expect($hook('form-dialog-modal-button-0').prop('tabindex')).to.equal(0)
     })
 
-    describe('when subtitle present', function () {
-      beforeEach(function () {
-        this.set('subtitle', 'Foo bar')
-      })
+    it('should have second button with tabIndex of 0', function () {
+      expect($hook('form-dialog-modal-button-1').prop('tabindex')).to.equal(0)
+    })
+  })
 
-      it('renders subtitle', function () {
-        const $subtitle = this.$('.frost-modal-dialog-header-subtitle')
-        expect($subtitle).to.have.length(1)
-        expect($subtitle.text()).to.equal('Foo bar')
-      })
+  describe('when buttons are given tabIndex', function () {
+    beforeEach(function () {
+      this.set('buttons', [
+        {
+          priority: 'secondary',
+          tabIndex: 2,
+          text: 'Foo'
+        },
+        {
+          priority: 'secondary',
+          tabIndex: 1,
+          text: 'Bar'
+        }
+      ])
     })
 
-    describe('when subtitle not present', function () {
-      beforeEach(function () {
-        this.set('subtitle', undefined)
-      })
-
-      it('does not render subtitle DOM', function () {
-        expect(this.$('.frost-modal-dialog-header-subtitle')).to.have.length(0)
-      })
+    it('should have first button with tabIndex === 2', function () {
+      expect($hook('form-dialog-modal-button-0').prop('tabindex')).to.equal(2)
     })
 
-    describe('when footer text present', function () {
-      beforeEach(function () {
-        this.set('footer', 'Foo bar')
-      })
+    it('should have second button with tabIndex === 1', function () {
+      expect($hook('form-dialog-modal-button-1').prop('tabindex')).to.equal(1)
+    })
+  })
 
-      it('renders footer text', function () {
-        const $footer = this.$('.frost-modal-dialog-footer-content')
-        expect($footer).to.have.length(1)
-        expect($footer.text().trim()).to.equal('Foo bar')
-      })
+  describe('when buttons not present', function () {
+    beforeEach(function () {
+      this.set('buttons', undefined)
     })
 
-    describe('when footer text not present', function () {
-      beforeEach(function () {
-        this.set('footer', undefined)
-      })
-
-      it('does not render footer text DOM', function () {
-        expect(this.$('.frost-modal-dialog-footer-content')).to.have.length(0)
-      })
+    it('only renders cancel and create buttons', function () {
+      expect(this.$('.frost-modal-dialog-footer button')).to.have.length(2)
     })
-
-    describe('when buttons present', function () {
-      beforeEach(function () {
-        this.set('buttons', [
-          {
-            priority: 'secondary',
-            text: 'Foo'
-          },
-          {
-            priority: 'secondary',
-            text: 'Bar'
-          }
-        ])
-      })
-
-      it('renders custom buttons plus cancel and create buttons', function () {
-        expect(this.$('.frost-modal-dialog-footer button')).to.have.length(4)
-      })
-
-      it('should have first button with tabIndex of 0', function () {
-        expect($hook('form-dialog-modal-button-0').prop('tabindex')).to.equal(0)
-      })
-
-      it('should have second button with tabIndex of 0', function () {
-        expect($hook('form-dialog-modal-button-1').prop('tabindex')).to.equal(0)
-      })
-    })
-
-    describe('when buttons are given tabIndex', function () {
-      beforeEach(function () {
-        this.set('buttons', [
-          {
-            priority: 'secondary',
-            tabIndex: 2,
-            text: 'Foo'
-          },
-          {
-            priority: 'secondary',
-            tabIndex: 1,
-            text: 'Bar'
-          }
-        ])
-      })
-
-      it('should have first button with tabIndex === 2', function () {
-        expect($hook('form-dialog-modal-button-0').prop('tabindex')).to.equal(2)
-      })
-
-      it('should have second button with tabIndex === 1', function () {
-        expect($hook('form-dialog-modal-button-1').prop('tabindex')).to.equal(1)
-      })
-    })
-
-    describe('when buttons not present', function () {
-      beforeEach(function () {
-        this.set('buttons', undefined)
-      })
-
-      it('only renders cancel and create buttons', function () {
-        expect(this.$('.frost-modal-dialog-footer button')).to.have.length(2)
-      })
-    })
-  }
-)
+  })
+})

--- a/tests/integration/components/frost-modal-info-message-test.js
+++ b/tests/integration/components/frost-modal-info-message-test.js
@@ -1,133 +1,124 @@
-import { expect } from 'chai'
-import {
-  $hook,
-  initialize as initializeHook
-} from 'ember-hook'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
+import {$hook, initialize as initializeHook} from 'ember-hook'
 import hbs from 'htmlbars-inline-precompile'
-import { beforeEach, describe } from 'mocha'
+import {beforeEach, describe, it} from 'mocha'
 
-describeComponent(
-  'frost-modal-info-message',
-  'Integration: FrostModalInfoMessageComponent',
-  {
-    integration: true
-  },
-  function () {
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = integration('frost-modal-info-message')
+describe(test.label, function () {
+  test.setup()
+
+  beforeEach(function () {
+    initializeHook()
+    this.set('closeModal', () => {
+      this.set('isModalVisible', false)
+    })
+    this.set('isModalVisible', true)
+
+    this.render(hbs`
+      {{frost-modal-outlet}}
+
+      {{frost-modal-info-message
+        buttons=buttons
+        footer=footer
+        hook='info-dialog'
+        isVisible=isModalVisible
+        subtitle=subtitle
+        summary='Summary'
+        title='Title'
+        onClose=(action closeModal)
+      }}
+    `)
+  })
+
+  it('renders', function (done) {
+    this.timeout(10000)
+    expect($hook('info-dialog-modal'), 'Is modal visible')
+      .to.have.length(1)
+    return capture('info', done, {
+      targetElement: this.$('.frost-modal-outlet-container.message')[0],
+      experimentalSvgs: false
+    })
+  })
+
+  it('closes on confirm', function () {
+    $hook('info-dialog-modal-confirm').click()
+
+    expect($hook('info-dialog-modal'), 'Is modal hidden')
+      .to.have.length(0)
+  })
+
+  describe('when subtitle present', function () {
     beforeEach(function () {
-      initializeHook()
-      this.set('closeModal', () => {
-        this.set('isModalVisible', false)
-      })
-      this.set('isModalVisible', true)
-
-      this.render(hbs`
-        {{frost-modal-outlet}}
-
-        {{frost-modal-info-message
-          buttons=buttons
-          footer=footer
-          hook='info-dialog'
-          isVisible=isModalVisible
-          subtitle=subtitle
-          summary='Summary'
-          title='Title'
-          onClose=(action closeModal)
-        }}
-      `)
+      this.set('subtitle', 'Foo bar')
     })
 
-    it('renders', function (done) {
-      this.timeout(10000)
-      expect($hook('info-dialog-modal'), 'Is modal visible')
-        .to.have.length(1)
-      return capture('info', done, {
-        targetElement: this.$('.frost-modal-outlet-container.message')[0],
-        experimentalSvgs: false
-      })
+    it('renders subtitle', function () {
+      const $subtitle = this.$('.frost-modal-dialog-header-subtitle')
+      expect($subtitle).to.have.length(1)
+      expect($subtitle.text()).to.equal('Foo bar')
+    })
+  })
+
+  describe('when subtitle not present', function () {
+    beforeEach(function () {
+      this.set('subtitle', undefined)
     })
 
-    it('closes on confirm', function () {
-      $hook('info-dialog-modal-confirm').click()
+    it('does not render subtitle DOM', function () {
+      expect(this.$('.frost-modal-dialog-header-subtitle')).to.have.length(0)
+    })
+  })
 
-      expect($hook('info-dialog-modal'), 'Is modal hidden')
-        .to.have.length(0)
+  describe('when footer text present', function () {
+    beforeEach(function () {
+      this.set('footer', 'Foo bar')
     })
 
-    describe('when subtitle present', function () {
-      beforeEach(function () {
-        this.set('subtitle', 'Foo bar')
-      })
+    it('renders footer text', function () {
+      const $footer = this.$('.frost-modal-dialog-footer-content')
+      expect($footer).to.have.length(1)
+      expect($footer.text().trim()).to.equal('Foo bar')
+    })
+  })
 
-      it('renders subtitle', function () {
-        const $subtitle = this.$('.frost-modal-dialog-header-subtitle')
-        expect($subtitle).to.have.length(1)
-        expect($subtitle.text()).to.equal('Foo bar')
-      })
+  describe('when footer text not present', function () {
+    beforeEach(function () {
+      this.set('footer', undefined)
     })
 
-    describe('when subtitle not present', function () {
-      beforeEach(function () {
-        this.set('subtitle', undefined)
-      })
+    it('does not render footer text DOM', function () {
+      expect(this.$('.frost-modal-dialog-footer-content')).to.have.length(0)
+    })
+  })
 
-      it('does not render subtitle DOM', function () {
-        expect(this.$('.frost-modal-dialog-header-subtitle')).to.have.length(0)
-      })
+  describe('when buttons present', function () {
+    beforeEach(function () {
+      this.set('buttons', [
+        {
+          priority: 'secondary',
+          text: 'Foo'
+        },
+        {
+          priority: 'secondary',
+          text: 'Bar'
+        }
+      ])
     })
 
-    describe('when footer text present', function () {
-      beforeEach(function () {
-        this.set('footer', 'Foo bar')
-      })
+    it('renders custom buttons plus cancel and create buttons', function () {
+      expect(this.$('.frost-modal-dialog-footer button')).to.have.length(4)
+    })
+  })
 
-      it('renders footer text', function () {
-        const $footer = this.$('.frost-modal-dialog-footer-content')
-        expect($footer).to.have.length(1)
-        expect($footer.text().trim()).to.equal('Foo bar')
-      })
+  describe('when buttons not present', function () {
+    beforeEach(function () {
+      this.set('buttons', undefined)
     })
 
-    describe('when footer text not present', function () {
-      beforeEach(function () {
-        this.set('footer', undefined)
-      })
-
-      it('does not render footer text DOM', function () {
-        expect(this.$('.frost-modal-dialog-footer-content')).to.have.length(0)
-      })
+    it('only renders cancel and create buttons', function () {
+      expect(this.$('.frost-modal-dialog-footer button')).to.have.length(2)
     })
-
-    describe('when buttons present', function () {
-      beforeEach(function () {
-        this.set('buttons', [
-          {
-            priority: 'secondary',
-            text: 'Foo'
-          },
-          {
-            priority: 'secondary',
-            text: 'Bar'
-          }
-        ])
-      })
-
-      it('renders custom buttons plus cancel and create buttons', function () {
-        expect(this.$('.frost-modal-dialog-footer button')).to.have.length(4)
-      })
-    })
-
-    describe('when buttons not present', function () {
-      beforeEach(function () {
-        this.set('buttons', undefined)
-      })
-
-      it('only renders cancel and create buttons', function () {
-        expect(this.$('.frost-modal-dialog-footer button')).to.have.length(2)
-      })
-    })
-  }
-)
+  })
+})

--- a/tests/integration/components/frost-modal-warn-message-test.js
+++ b/tests/integration/components/frost-modal-warn-message-test.js
@@ -1,145 +1,136 @@
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
 import hbs from 'htmlbars-inline-precompile'
-import {
-  $hook,
-  initialize as initializeHook
-} from 'ember-hook'
-import { beforeEach, describe } from 'mocha'
+import {$hook, initialize as initializeHook} from 'ember-hook'
+import {beforeEach, describe, it} from 'mocha'
 
-describeComponent(
-  'frost-modal-warn-message',
-  'Integration: FrostModalWarnMessageComponent',
-  {
-    integration: true
-  },
-  function () {
-    let props
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
+const test = integration('frost-modal-warn-message')
+describe(test.label, function () {
+  test.setup()
+
+  let props
+
+  beforeEach(function () {
+    initializeHook()
+    this.timeout(10000)
+    this.set('closeModal', () => {
+      this.set('isModalVisible', false)
+    })
+    props = {
+      hook: 'warning-dialog',
+      onCancel: sinon.spy(),
+      isModalVisible: true
+    }
+    this.setProperties(props)
+    this.render(hbs`
+      {{frost-modal-outlet}}
+      {{frost-modal-warn-message
+        buttons=buttons
+        cancel=(hash
+          text='Nope'
+        )
+        footer=footer
+        hook=hook
+        isVisible=isModalVisible
+        subtitle=subtitle
+        summary='Take this'
+        title="It's dangerous to go alone!"
+        onCancel=onCancel
+        onClose=(action closeModal)
+      }}`)
+  })
+
+  it('renders', function (done) {
+    this.timeout(10000)
+    expect($hook(props.hook), 'Is modal visible')
+      .to.have.length(1)
+
+    return capture('warning-dialog', done, {
+      targetElement: this.$('.frost-modal-outlet-container.message')[0],
+      experimentalSvgs: false
+    })
+  })
+
+  it('cancel triggers callback and close', function () {
+    $hook('warning-dialog-modal-cancel').click()
+
+    expect(props.onCancel.called, 'Callback triggered')
+      .to.be.true
+    expect($hook('warning-dialog-modal'), 'Is modal hidden')
+      .to.have.length(0)
+  })
+
+  describe('when subtitle present', function () {
     beforeEach(function () {
-      initializeHook()
-      this.timeout(10000)
-      this.set('closeModal', () => {
-        this.set('isModalVisible', false)
-      })
-      props = {
-        hook: 'warning-dialog',
-        onCancel: sinon.spy(),
-        isModalVisible: true
-      }
-      this.setProperties(props)
-      this.render(hbs`
-        {{frost-modal-outlet}}
-        {{frost-modal-warn-message
-          buttons=buttons
-          cancel=(hash
-            text='Nope'
-          )
-          footer=footer
-          hook=hook
-          isVisible=isModalVisible
-          subtitle=subtitle
-          summary='Take this'
-          title="It's dangerous to go alone!"
-          onCancel=onCancel
-          onClose=(action closeModal)
-        }}`)
+      this.set('subtitle', 'Foo bar')
     })
 
-    it('renders', function (done) {
-      this.timeout(10000)
-      expect($hook(props.hook), 'Is modal visible')
-        .to.have.length(1)
+    it('renders subtitle', function () {
+      const $subtitle = this.$('.frost-modal-dialog-header-subtitle')
+      expect($subtitle).to.have.length(1)
+      expect($subtitle.text()).to.equal('Foo bar')
+    })
+  })
 
-      return capture('warning-dialog', done, {
-        targetElement: this.$('.frost-modal-outlet-container.message')[0],
-        experimentalSvgs: false
-      })
+  describe('when subtitle not present', function () {
+    beforeEach(function () {
+      this.set('subtitle', undefined)
     })
 
-    it('cancel triggers callback and close', function () {
-      $hook('warning-dialog-modal-cancel').click()
+    it('does not render subtitle DOM', function () {
+      expect(this.$('.frost-modal-dialog-header-subtitle')).to.have.length(0)
+    })
+  })
 
-      expect(props.onCancel.called, 'Callback triggered')
-        .to.be.true
-      expect($hook('warning-dialog-modal'), 'Is modal hidden')
-        .to.have.length(0)
+  describe('when footer text present', function () {
+    beforeEach(function () {
+      this.set('footer', 'Foo bar')
     })
 
-    describe('when subtitle present', function () {
-      beforeEach(function () {
-        this.set('subtitle', 'Foo bar')
-      })
+    it('renders footer text', function () {
+      const $footer = this.$('.frost-modal-dialog-footer-content')
+      expect($footer).to.have.length(1)
+      expect($footer.text().trim()).to.equal('Foo bar')
+    })
+  })
 
-      it('renders subtitle', function () {
-        const $subtitle = this.$('.frost-modal-dialog-header-subtitle')
-        expect($subtitle).to.have.length(1)
-        expect($subtitle.text()).to.equal('Foo bar')
-      })
+  describe('when footer text not present', function () {
+    beforeEach(function () {
+      this.set('footer', undefined)
     })
 
-    describe('when subtitle not present', function () {
-      beforeEach(function () {
-        this.set('subtitle', undefined)
-      })
+    it('does not render footer text DOM', function () {
+      expect(this.$('.frost-modal-dialog-footer-content')).to.have.length(0)
+    })
+  })
 
-      it('does not render subtitle DOM', function () {
-        expect(this.$('.frost-modal-dialog-header-subtitle')).to.have.length(0)
-      })
+  describe('when buttons present', function () {
+    beforeEach(function () {
+      this.set('buttons', [
+        {
+          priority: 'secondary',
+          text: 'Foo'
+        },
+        {
+          priority: 'secondary',
+          text: 'Bar'
+        }
+      ])
     })
 
-    describe('when footer text present', function () {
-      beforeEach(function () {
-        this.set('footer', 'Foo bar')
-      })
+    it('renders custom buttons plus cancel and create buttons', function () {
+      expect(this.$('.frost-modal-dialog-footer button')).to.have.length(4)
+    })
+  })
 
-      it('renders footer text', function () {
-        const $footer = this.$('.frost-modal-dialog-footer-content')
-        expect($footer).to.have.length(1)
-        expect($footer.text().trim()).to.equal('Foo bar')
-      })
+  describe('when buttons not present', function () {
+    beforeEach(function () {
+      this.set('buttons', undefined)
     })
 
-    describe('when footer text not present', function () {
-      beforeEach(function () {
-        this.set('footer', undefined)
-      })
-
-      it('does not render footer text DOM', function () {
-        expect(this.$('.frost-modal-dialog-footer-content')).to.have.length(0)
-      })
+    it('only renders cancel and create buttons', function () {
+      expect(this.$('.frost-modal-dialog-footer button')).to.have.length(2)
     })
-
-    describe('when buttons present', function () {
-      beforeEach(function () {
-        this.set('buttons', [
-          {
-            priority: 'secondary',
-            text: 'Foo'
-          },
-          {
-            priority: 'secondary',
-            text: 'Bar'
-          }
-        ])
-      })
-
-      it('renders custom buttons plus cancel and create buttons', function () {
-        expect(this.$('.frost-modal-dialog-footer button')).to.have.length(4)
-      })
-    })
-
-    describe('when buttons not present', function () {
-      beforeEach(function () {
-        this.set('buttons', undefined)
-      })
-
-      it('only renders cancel and create buttons', function () {
-        expect(this.$('.frost-modal-dialog-footer button')).to.have.length(2)
-      })
-    })
-  }
-)
+  })
+})

--- a/tests/integration/helpers/frost-modal-blur-active-test.js
+++ b/tests/integration/helpers/frost-modal-blur-active-test.js
@@ -1,52 +1,46 @@
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
 import wait from 'ember-test-helpers/wait'
 import hbs from 'htmlbars-inline-precompile'
-import { beforeEach } from 'mocha'
+import {beforeEach, describe, it} from 'mocha'
 
-describeComponent(
-  'frost-modal-blur-active',
-  'Integration: FrostModalBlurActiveHelper',
-  {
-    integration: true
-  },
-  function () {
-    beforeEach(function () {
-      this.inject.service('frost-modal')
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.render(hbs`
-        <span id='active'>{{frost-modal-blur-active}}</span>
-      `)
+const test = integration('frost-modal-blur-active')
+describe(test.label, function () {
+  test.setup()
 
-      this.modalName = 'foo-modal'
+  beforeEach(function () {
+    this.inject.service('frost-modal')
+
+    this.render(hbs`
+      <span id='active'>{{frost-modal-blur-active}}</span>
+    `)
+
+    this.modalName = 'foo-modal'
+  })
+
+  it('renders', function () {
+    expect(this.$('#active').text().trim()).to.equal('false')
+  })
+
+  it('reflects the active state of the frost-modal service', function () {
+    const active = true
+
+    this.get('frost-modal').setState(this.modalName, active)
+
+    return wait().then(() => {
+      expect(this.$('#active').text().trim()).to.equal('true')
     })
+  })
 
-    it('renders', function () {
+  it("doesn't blur when the noBlur property is true", function () {
+    const active = true
+    const noBlur = true
+
+    this.get('frost-modal').setState(this.modalName, active, noBlur)
+
+    return wait().then(() => {
       expect(this.$('#active').text().trim()).to.equal('false')
     })
-
-    it('reflects the active state of the frost-modal service', function () {
-      const active = true
-
-      this.get('frost-modal').setState(this.modalName, active)
-
-      return wait().then(() => {
-        expect(this.$('#active').text().trim()).to.equal('true')
-      })
-    })
-
-    it("doesn't blur when the noBlur property is true", function () {
-      const active = true
-      const noBlur = true
-
-      this.get('frost-modal').setState(this.modalName, active, noBlur)
-
-      return wait().then(() => {
-        expect(this.$('#active').text().trim()).to.equal('false')
-      })
-    })
-  }
-)
+  })
+})

--- a/tests/unit/helpers/array-test.js
+++ b/tests/unit/helpers/array-test.js
@@ -1,13 +1,8 @@
-import { expect } from 'chai'
-import {
-  describe,
-  it
-} from 'mocha'
-import {
-  array
-} from 'ember-frost-modal/helpers/array'
+import {expect} from 'chai'
+import {describe, it} from 'mocha'
+import {array} from 'ember-frost-modal/helpers/array'
 
-describe('ArrayHelper', function () {
+describe('Unit / Helper / array', function () {
   // Replace this with your real tests.
   it('works', function () {
     let result = array(42)

--- a/tests/unit/helpers/frost-modal-animation-test.js
+++ b/tests/unit/helpers/frost-modal-animation-test.js
@@ -1,9 +1,6 @@
-import {
-  describe,
-  it
-} from 'mocha'
+import {describe, it} from 'mocha'
 
-describe('FrostModalAnimationHelper', function () {
+describe('Unit / Helper / frost-modal-animation', function () {
   it('works', function () {
   })
 })

--- a/tests/unit/helpers/frost-modal-outlet-animation-test.js
+++ b/tests/unit/helpers/frost-modal-outlet-animation-test.js
@@ -1,13 +1,8 @@
-// import { expect } from 'chai'
-import {
-  describe,
-  it
-} from 'mocha'
-// import {
-//   frostModalOutletAnimation
-// } from 'ember-frost-modal/helpers/frost-modal-outlet-animation'
+// import {expect} from 'chai'
+import {describe, it} from 'mocha'
+// import {frostModalOutletAnimation} from 'ember-frost-modal/helpers/frost-modal-outlet-animation'
 
-describe('FrostModalOutletAnimationHelper', function () {
+describe('Unit / Helper / frost-modal-outlet-animation', function () {
   // Replace this with your real tests.
   it('works', function () {
     // let result = frostModalOutletAnimation(42)

--- a/tests/unit/services/frost-modal-test.js
+++ b/tests/unit/services/frost-modal-test.js
@@ -1,21 +1,19 @@
-import { expect } from 'chai'
-import {
-  describeModule,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
+import {setupTest} from 'ember-mocha'
+import {beforeEach, describe, it} from 'mocha'
 
-describeModule(
-  'service:frost-modal',
-  'FrostModalService',
-  {
-    // Specify the other units that are required for this test.
-    // needs: ['service:foo']
-  },
-  function () {
-    // Replace this with your real tests.
-    it('exists', function () {
-      let service = this.subject()
-      expect(service).to.be.ok
-    })
-  }
-)
+describe('Unit / Service / frost-modal', function () {
+  setupTest('service:frost-modal', {
+    unit: true
+  })
+
+  let service
+
+  beforeEach(function () {
+    service = this.subject()
+  })
+
+  it('exists', function () {
+    expect(service).to.be.ok
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [X] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Closes: https://github.com/ciena-frost/ember-frost-modal/issues/79
# CHANGELOG
* **Updated** integration tests to remove the deprecated use of `describeComponent()`
* **Updated** service unit test to use setupTest() from `ember-mocha`
* **Updated** `ember-test-utils` version