### PR TITLE
Upgrade ember-cli 2.12.3 inter-dependencies

### DIFF
--- a/blueprints/ember-frost-modal/index.js
+++ b/blueprints/ember-frost-modal/index.js
@@ -6,10 +6,10 @@ module.exports = {
 
   afterInstall: function (options) {
     const addonsToAdd = [
-      {name: 'ember-frost-core', target: '^1.14.3'},
-      {name: 'ember-get-config', target: '~0.1.11'},
+      {name: 'ember-frost-core', target: '1.23.10'},
+      {name: 'ember-get-config', target: '~0.2.1'},
       {name: 'ember-ignore-children-helper', target: '^1.0.0'},
-      {name: 'liquid-fire', target: '~0.26.1'}
+      {name: 'liquid-fire', target: '0.27.2'}
     ]
 
     // Get the packages installed in the consumer app/addon. Packages that are already installed in the consumer within

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ember-cli-code-coverage": "^0.3.10",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-frost-blueprints": "1.2.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
+    "ember-cli-htmlbars-inline-precompile": "0.3.12",
     "ember-cli-import-polyfill": "0.2.0",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mocha": "~0.13.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ember-cli-chai": "~0.3.0",
     "ember-cli-code-coverage": "^0.3.10",
     "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-frost-blueprints": "1.2.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.6",
     "ember-cli-import-polyfill": "0.2.0",
     "ember-cli-inject-live-reload": "^1.4.1",
@@ -50,7 +51,7 @@
     "ember-computed-decorators": "~0.3.0",
     "ember-concurrency": "~0.8.1",
     "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-elsewhere": "1.0.0",
+    "ember-elsewhere": "1.0.1",
     "ember-export-application-global": "^1.0.5",
     "ember-fetch": "1.4.0",
     "ember-frost-bunsen": "^14.2.0",
@@ -80,8 +81,8 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-cli-sass": "^5.3.0",
-    "ember-frost-core": "^1.14.3"
+    "ember-cli-sass": "5.6.0",
+    "ember-frost-core": "1.23.10"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Upgrade ember-cli 2.12.3 inter-dependencies