### PR TITLE
Remove unused ember-simple-uuid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "ember-moment": "^7.3.0",
     "ember-prop-types": "^3.11.0",
     "ember-resolver": "^2.0.3",
-    "ember-simple-uuid": "0.1.4",
     "ember-sinon": "0.7.0",
     "ember-source": "~2.12.0",
     "ember-spread": "^1.1.4",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Remove unused `ember-simple-uuid` dependency