### PR TITLE
Add optional promise-aware behavior to frost-modal-form

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,13 +2,5 @@ module.exports = {
   extends: 'frost-standard',
   globals: {
     capture: false
-  },
-  rules: {
-    'ember-standard/prop-types': 2,
-    'mocha/valid-test-description': 0,
-    'no-multi-spaces': [
-      'error',
-      {ignoreEOLComments: true}
-    ]
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,5 +2,13 @@ module.exports = {
   extends: 'frost-standard',
   globals: {
     capture: false
+  },
+  rules: {
+    'ember-standard/prop-types': 2,
+    'mocha/valid-test-description': 0,
+    'no-multi-spaces': [
+      'error',
+      {ignoreEOLComments: true}
+    ]
   }
 }

--- a/addon/components/dialogs/form.js
+++ b/addon/components/dialogs/form.js
@@ -17,22 +17,6 @@ export default FrostModalBinding.extend(PropTypesMixin, {
       text: PropTypes.string,
       title: PropTypes.string
     }),
-    confirm: PropTypes.shape({
-      disabled: PropTypes.bool,
-      isVisible: PropTypes.bool,
-      tabIndex: PropTypes.number,
-      text: PropTypes.string,
-      title: PropTypes.string
-    }),
-    // This is only used when we are overriding the confirm button's state, which
-    // is useful if we want to prevent spamming Confirm until onConfirm resolves.
-    disabledConfirm: PropTypes.shape({
-      disabled: PropTypes.bool,
-      isVisible: PropTypes.bool,
-      tabIndex: PropTypes.number,
-      text: PropTypes.string,
-      title: PropTypes.string
-    }),
     footer: PropTypes.string,
     form: PropTypes.oneOfType([
       PropTypes.object,
@@ -54,13 +38,6 @@ export default FrostModalBinding.extend(PropTypesMixin, {
     return {
       animation: form,
       classModifier: 'form',
-      disabledConfirm: {
-        disabled: true,
-        isVisible: true,
-        // This is OK because we only need this if the confirm button is visible anyway.
-        text: 'Confirm',
-        title: 'Waiting for confirm to resolve' // never shown because button is disabled
-      },
       modal: 'frost-modal-dialog'
     }
   },
@@ -69,16 +46,14 @@ export default FrostModalBinding.extend(PropTypesMixin, {
 
   @readOnly
   @computed('forceDisabledConfirm')
-  params (forceDisabledConfirm) {
-    // We look these up here, rather than using arguments to computed(), so that we avoid double-computed errors
-    // when we hide the modal.  The recomputation seems to still happen when confirm is changed
-    // (e.g. validation state changes), thankfully.
-    const {confirm, disabledConfirm} = this.getProperties('confirm', 'disabledConfirm')
-    const _confirm = forceDisabledConfirm ? disabledConfirm : confirm
+  params () {
+    // We look up confirmButtonProps here, rather than using arguments to computed(), so that we avoid
+    // double-computed assertion errors when we hide the modal.
+    // The recomputation seems to still happen when confirm is changed (e.g. validation state changes), thankfully.
     return {
       buttons: this.buttons,
       cancel: this.cancel,
-      confirm: _confirm,
+      confirm: this.get('confirmButtonProps'), // computed in frost-modal-binding
       content: this.form,
       footer: this.footer,
       links: this.links,

--- a/addon/components/dialogs/form.js
+++ b/addon/components/dialogs/form.js
@@ -14,13 +14,24 @@ export default FrostModalBinding.extend(PropTypesMixin, {
       disabled: PropTypes.bool,
       isVisible: PropTypes.bool,
       tabIndex: PropTypes.number,
-      text: PropTypes.string
+      text: PropTypes.string,
+      title: PropTypes.string
     }),
     confirm: PropTypes.shape({
       disabled: PropTypes.bool,
       isVisible: PropTypes.bool,
       tabIndex: PropTypes.number,
-      text: PropTypes.string
+      text: PropTypes.string,
+      title: PropTypes.string
+    }),
+    // This is only used when we are overriding the confirm button's state, which
+    // is useful if we want to prevent spamming Confirm until onConfirm resolves.
+    disabledConfirm: PropTypes.shape({
+      disabled: PropTypes.bool,
+      isVisible: PropTypes.bool,
+      tabIndex: PropTypes.number,
+      text: PropTypes.string,
+      title: PropTypes.string
     }),
     footer: PropTypes.string,
     form: PropTypes.oneOfType([
@@ -43,18 +54,31 @@ export default FrostModalBinding.extend(PropTypesMixin, {
     return {
       animation: form,
       classModifier: 'form',
+      disabledConfirm: {
+        disabled: true,
+        isVisible: true,
+        // This is OK because we only need this if the confirm button is visible anyway.
+        text: 'Confirm',
+        title: 'Waiting for confirm to resolve' // never shown because button is disabled
+      },
       modal: 'frost-modal-dialog'
     }
   },
 
   // == Computed properties ===================================================
+
   @readOnly
-  @computed()
-  params () {
+  @computed('forceDisabledConfirm')
+  params (forceDisabledConfirm) {
+    // We look these up here, rather than using arguments to computed(), so that we avoid double-computed errors
+    // when we hide the modal.  The recomputation seems to still happen when confirm is changed
+    // (e.g. validation state changes), thankfully.
+    const {confirm, disabledConfirm} = this.getProperties('confirm', 'disabledConfirm')
+    const _confirm = forceDisabledConfirm ? disabledConfirm : confirm
     return {
       buttons: this.buttons,
       cancel: this.cancel,
-      confirm: this.confirm,
+      confirm: _confirm,
       content: this.form,
       footer: this.footer,
       links: this.links,

--- a/addon/components/frost-modal-about-dialog.js
+++ b/addon/components/frost-modal-about-dialog.js
@@ -4,7 +4,7 @@ import layout from '../templates/components/frost-modal-about-dialog'
 
 export default Component.extend({
 
-   // == Component properties ==================================================
+  // == Component properties ==================================================
 
   classNames: ['frost-modal-about-dialog'],
   layout

--- a/addon/components/frost-modal-binding.js
+++ b/addon/components/frost-modal-binding.js
@@ -155,7 +155,7 @@ const FrostModalBinding = Component.extend(PropTypesMixin, {
     }
 
     confirmed = confirmed.catch((err) => {
-      deps.Logger.log(err)
+      deps.Logger.error(err)
     })
 
     if (this.get('disableConfirmUntilOnConfirmResolves')) {

--- a/addon/components/frost-modal-binding.js
+++ b/addon/components/frost-modal-binding.js
@@ -1,8 +1,12 @@
 import Ember from 'ember'
-const {Component, inject, run} = Ember
+const {Component, Logger, inject, run} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import layout from '../templates/components/frost-modal-binding'
 import PropTypesMixin, {PropTypes} from 'ember-prop-types'
+
+export const deps = {
+  Logger
+}
 
 /**
  * Helper to ensure we don't try to resolve something that isn't a then-able
@@ -170,6 +174,13 @@ const FrostModalBinding = Component.extend(PropTypesMixin, {
           // Otherwise, we don't care about promise awareness
           this.onClose()
         }
+      }
+
+      if (_isThenable) {
+        // Normally, onConfirm will already catch and do things with any promise errors.
+        confirmed = confirmed.catch((err) => {
+          deps.Logger.log(err)
+        })
       }
 
       if (_isThenable && this.get('disableConfirmUntilOnConfirmResolves')) {

--- a/addon/components/frost-modal-binding.js
+++ b/addon/components/frost-modal-binding.js
@@ -148,7 +148,7 @@ const FrostModalBinding = Component.extend(PropTypesMixin, {
     // handle closeOnConfirm + button-disabling separately, so that we still protect from spamming
     // even if we want to avoid automatic invocation of onClose
 
-    if (this.get('closeOnConfirm') === true) {
+    if (this.get('closeOnConfirm')) {
       confirmed = confirmed.then(() => {
         this.onClose()
       })
@@ -196,7 +196,7 @@ const FrostModalBinding = Component.extend(PropTypesMixin, {
       if (_isThenable) {
         return this._handleThenableOnConfirmResult(confirmed)
       } else {
-        if (this.get('closeOnConfirm') === true) {
+        if (this.get('closeOnConfirm')) {
           this.onClose()
         }
         return confirmed

--- a/addon/components/frost-modal-binding.js
+++ b/addon/components/frost-modal-binding.js
@@ -37,12 +37,12 @@ const FrostModalBinding = Component.extend(PropTypesMixin, {
     // desired properties of the 'Confirm' button
     confirm: PropTypes.shape({
       disabled: PropTypes.bool,
+      disabledText: PropTypes.string,
       isVisible: PropTypes.bool,
       tabIndex: PropTypes.number,
       text: PropTypes.string,
       title: PropTypes.string
     }),
-    disabledConfirmText: PropTypes.string,
     disableConfirmUntilOnConfirmResolves: PropTypes.bool,
     isVisible: PropTypes.bool.isRequired,
     params: PropTypes.oneOfType([
@@ -67,11 +67,13 @@ const FrostModalBinding = Component.extend(PropTypesMixin, {
       closeOnOutsideClick: false,
       confirm: {
         disabled: false,
+        disabledText: 'Confirm',
         isVisible: true,
         text: 'Confirm'
       },
       _defaultConfirm: {
         disabled: false,
+        disabledText: 'Confirm',
         isVisible: true,
         text: 'Confirm'
       },
@@ -84,19 +86,18 @@ const FrostModalBinding = Component.extend(PropTypesMixin, {
   // == Computed Properties ===================================================
 
   @readOnly
-  @computed('confirm', 'forceDisabledConfirm', 'disabledConfirmText', '_defaultConfirm')
+  @computed('confirm', 'forceDisabledConfirm', '_defaultConfirm')
   /**
    * Computed our Confirm button's props so that we can alter text/disabled in concord with onConfirm promises
    * TODO: Update confirm/error/info/warn to use this as well: they currently use this.confirm directly
    * @param {Object} confirm - normal props for confirm button
    * @param {Boolean} forceDisabledConfirm - whether to override normal confirm button props
-   * @param {String} disabledConfirmText - optional replacement text for the confirm button
    * @param {Object} defaultConfirm - defaults for confirm button, in case someone doesn't specify text
    * @returns {Object} - props to use when displaying the confirm button
    */
-  confirmButtonProps (confirm, forceDisabledConfirm, disabledConfirmText, defaultConfirm) {
+  confirmButtonProps (confirm, forceDisabledConfirm, defaultConfirm) {
     if (forceDisabledConfirm) {
-      const text = disabledConfirmText || confirm.text || defaultConfirm.text
+      const text = confirm.disabledText || defaultConfirm.disabledText || confirm.text || defaultConfirm.text
       return {
         ...confirm,
         disabled: true,

--- a/addon/services/frost-modal.js
+++ b/addon/services/frost-modal.js
@@ -4,7 +4,7 @@ const {
   run: {
     scheduleOnce
   }
- } = Ember
+} = Ember
 
 export default Service.extend({
 

--- a/addon/templates/components/frost-modal-dialog.hbs
+++ b/addon/templates/components/frost-modal-dialog.hbs
@@ -82,6 +82,7 @@
     size='medium'
     tabIndex=(if (or params.cancel.tabIndex (eq params.cancel.tabIndex 0)) params.cancel.tabIndex 1)
     text=(if params.cancel.text params.cancel.text 'Cancel')
+    title=(if params.cancel.title params.cancel.title)
 
     onClick=onCancel
   }}
@@ -98,6 +99,7 @@
       size='medium'
       tabIndex=(if button.tabIndex button.tabIndex 0)
       text=button.text
+      title=button.title
 
       onClick=button.onClick
     }}
@@ -113,6 +115,7 @@
     size='medium'
     tabIndex=(if params.confirm.tabIndex params.confirm.tabIndex 0)
     text=(if params.confirm.text params.confirm.text 'Confirm')
+    title=(if params.confirm.title params.confirm.title)
 
     onClick=onConfirm
   }}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -2,7 +2,7 @@
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon')
 
 module.exports = function (defaults) {
-  var app = new EmberAddon(defaults, {
+  const app = new EmberAddon(defaults, {
     babel: {
       optional: ['es7.decorators']
     },

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 module.exports = {
   name: 'ember-frost-modal',
 
+  /* eslint-disable complexity */
   init: function () {
     this.options = this.options || {}
     this.options.babel = this.options.babel || {}
@@ -16,4 +17,5 @@ module.exports = {
     // eslint-disable-next-line no-unused-expressions
     this._super.init && this._super.init.apply(this, arguments)
   }
+  /* eslint-enable complexity */
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "bower": "^1.8.2",
     "broccoli-asset-rev": "^2.4.5",
+    "chai-jquery": "^2.0.0",
     "ember-browserify": "1.1.13",
     "ember-cli": "2.12.3",
     "ember-cli-chai": "~0.3.0",
@@ -71,10 +72,11 @@
     "ember-sinon": "0.7.0",
     "ember-source": "~2.12.0",
     "ember-spread": "^1.1.4",
-    "ember-test-utils": "^5.1.1",
+    "ember-test-utils": "^8.1.0",
     "ember-truth-helpers": "1.3.0",
     "liquid-fire": "0.27.2",
-    "loader.js": "^4.2.3"
+    "loader.js": "^4.2.3",
+    "sinon-chai": "^2.13.0"
   },
   "keywords": [
     "ember-addon",

--- a/tests/acceptance/frost-modal-outlet-test.js
+++ b/tests/acceptance/frost-modal-outlet-test.js
@@ -29,7 +29,7 @@ describe('Acceptance: FrostModalOutlet', function () {
       return visit('/frost-modal-outlet-test')
     })
 
-    it('renders as expected', function () {
+    it('should render as expected', function () {
       expect(currentPath()).to.equal('frost-modal-outlet-test')
       expect($hook('basic-modal'), 'Modal is initially hidden')
         .to.have.length(0)
@@ -40,7 +40,7 @@ describe('Acceptance: FrostModalOutlet', function () {
         return click($hook('launcher'))
       })
 
-      it('renders as expected', function () {
+      it('should render as expected', function () {
         expect($hook('basic-modal'), 'Modal becomes visible')
           .to.have.length(1)
       })
@@ -50,7 +50,7 @@ describe('Acceptance: FrostModalOutlet', function () {
           return click($hook('basic-modal-confirm'))
         })
 
-        it('renders as expected', function () {
+        it('should render as expected', function () {
           expect($hook('basic-modal'), 'Modal is dismissed')
             .to.have.length(0)
         })

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,8 +1,12 @@
 import config from './config/environment'
 import Ember from 'ember'
 const {Application} = Ember
+import {$hook, hook} from 'ember-hook'
 import loadInitializers from 'ember-load-initializers'
 import Resolver from './resolver'
+
+window.$hook = $hook
+window.hook = hook
 
 let App
 

--- a/tests/dummy/app/pods/application/template.hbs
+++ b/tests/dummy/app/pods/application/template.hbs
@@ -1,8 +1,4 @@
-<div class="demo-notification-container">
-  {{#each notifications as |notification|}}
-    {{notification-message notification=notification}}
-  {{/each}}
-</div>
+{{notification-container zindex=9999}}
 
 {{frost-modal-outlet}}
 

--- a/tests/dummy/app/pods/demo/confirm/template.hbs
+++ b/tests/dummy/app/pods/demo/confirm/template.hbs
@@ -1,10 +1,12 @@
 {{!-- BEGIN-SNIPPET confirm-api }}
   {{frost-modal-outlet}}
 
-  {{! use `object` instead of `hash` to resolve issue https://github.com/emberjs/ember.js/issues/14738. As `hash` does not have a `toString` method }}
+  {{! use `object` instead of `hash` to resolve issue
+      https://github.com/emberjs/ember.js/issues/14738
+      as `hash` does not have a `toString` method }}
   {{frost-modal-confirm-message
     buttons=(array
-      (object 
+      (object
         disabled= // true
         icon= // e.g. 'info'
         onClick= // e.g. (action 'info')

--- a/tests/dummy/app/pods/demo/dialog/template.hbs
+++ b/tests/dummy/app/pods/demo/dialog/template.hbs
@@ -31,7 +31,9 @@
 {{ END-SNIPPET --}}
 
 {{! BEGIN-SNIPPET dialog }}
-{{! use `object` instead of `hash` to resolve issue https://github.com/emberjs/ember.js/issues/14738. As `hash` does not have a `toString` method }}
+{{! use `object` instead of `hash` to resolve issue
+    https://github.com/emberjs/ember.js/issues/14738
+    as `hash` does not have a `toString` method }}
 {{frost-modal-binding 'frost-modal-dialog'
   hook='basic-dialog'
   isVisible=isDialogVisible
@@ -46,7 +48,7 @@
       name='warning'
     )
     links=(array
-       (object 
+      (object
         priority='secondary'
         route='demo.form'
         text='Moving on...'

--- a/tests/dummy/app/pods/demo/error/template.hbs
+++ b/tests/dummy/app/pods/demo/error/template.hbs
@@ -1,7 +1,9 @@
 {{!-- BEGIN-SNIPPET error-api }}
   {{frost-modal-outlet}}
 
-  {{! use `object` instead of `hash` to resolve issue https://github.com/emberjs/ember.js/issues/14738. As `hash` does not have a `toString` method }}
+  {{! use `object` instead of `hash` to resolve issue
+      https://github.com/emberjs/ember.js/issues/14738
+      as `hash` does not have a `toString` method }}
   {{frost-modal-error-message
     buttons=(array
       (object

--- a/tests/dummy/app/pods/demo/form-async/controller.js
+++ b/tests/dummy/app/pods/demo/form-async/controller.js
@@ -1,10 +1,13 @@
 /**
- * Demo of frost-modal-form with useful defaults
+ * Demo of frost-modal-form with optional progress indication
+ * until a promise is returned from the onConfirm callback,
+ * triggered with the showProgressUntilConfirmResolves option.
  */
 
 import Ember from 'ember'
-const {Controller, inject} = Ember
+const {Controller, RSVP, inject, run} = Ember
 const {service} = inject
+const {Promise} = RSVP
 
 export default Controller.extend({
   notifications: service('notification-messages'),
@@ -46,12 +49,14 @@ export default Controller.extend({
 
   actions: {
     closeForm () {
-      this.set('isFormValid', true)
-      this.set('isFormVisible', false)
-      this.set('simpleBunsenValue', Ember.Object({
-        firstName: 'Ada',
-        lastName: 'Lovelace'
-      }))
+      this.setProperties({
+        isFormValid: true,
+        isFormVisible: false,
+        simpleBunsenValue: {
+          firstName: 'Ada',
+          lastName: 'Lovelace'
+        }
+      })
     },
 
     openForm () {
@@ -62,14 +67,22 @@ export default Controller.extend({
       window.alert('OMG!')
     },
 
-    notifyClearAndClose () {
+    /**
+     * @returns {Promise} promise - a promise that resolves in a few seconds to imitate an async call
+     */
+    resolveLater () {
       this.get('notifications').addNotification({
-        message: JSON.stringify(this.get('simpleBunsenValue'), null, 2),
+        message: 'Showing progress indicator until async returns',
         type: 'success',
         autoClear: true,
-        clearDuration: 2000
+        clearDuration: 3000
       })
-      this.send('closeForm')
+
+      return new Promise((resolve) => {
+        run.later(() => {
+          resolve('success!')
+        }, 3000)
+      })
     },
 
     /**

--- a/tests/dummy/app/pods/demo/form-async/controller.js
+++ b/tests/dummy/app/pods/demo/form-async/controller.js
@@ -38,6 +38,9 @@ export default Controller.extend({
       age: {
         type: 'number',
         title: 'Age'
+      },
+      rejectPromise: {
+        type: 'boolean'
       }
     },
     required: ['lastName']
@@ -79,16 +82,37 @@ export default Controller.extend({
      * @returns {Promise} promise - a promise that resolves in a few seconds to imitate an async call
      */
     doSomethingAsync () {
-      this.get('notifications').addNotification({
-        message: 'Showing progress indicator until async returns',
-        type: 'success',
-        autoClear: true,
-        clearDuration: 3000
+      const resolves = !(this.get('bunsenValue.rejectPromise'))
+
+      const _notify = ({message, type}) => {
+        this.get('notifications').addNotification({
+          message,
+          type,
+          autoClear: true,
+          clearDuration: 3000
+        })
+      }
+
+      _notify({
+        message: `Showing progress indicator until async ${resolves ? 'resolves' : 'rejects'}`,
+        type: 'success'
       })
 
-      return new Promise((resolve) => {
+      return new Promise((resolve, reject) => {
         run.later(() => {
-          resolve('success!')
+          if (resolves) {
+            _notify({
+              message: 'Modal closes when the promise resolves',
+              type: 'success'
+            })
+            resolve('success!')
+          } else {
+            _notify({
+              message: 'Modal stays open when the promise rejects',
+              type: 'warning'
+            })
+            reject(new Error('failure!'))
+          }
         }, 3000)
       })
     },

--- a/tests/dummy/app/pods/demo/form-async/controller.js
+++ b/tests/dummy/app/pods/demo/form-async/controller.js
@@ -18,7 +18,8 @@ export default Controller.extend({
   isFormValid: true,
   isFormVisible: false,
 
-  simpleBunsenModel: {
+  // This would often be imported from a separate file, or provided by an external API.
+  bunsenModel: {
     type: 'object',
     properties: {
       firstName: {
@@ -42,17 +43,20 @@ export default Controller.extend({
     required: ['lastName']
   },
 
-  simpleBunsenValue: {
+  bunsenValue: {
     firstName: 'Ada',
     lastName: 'Lovelace'
   },
 
   actions: {
+    /**
+     * Hide our form and reset the values
+     */
     closeForm () {
       this.setProperties({
         isFormValid: true,
         isFormVisible: false,
-        simpleBunsenValue: {
+        bunsenValue: {
           firstName: 'Ada',
           lastName: 'Lovelace'
         }
@@ -68,9 +72,13 @@ export default Controller.extend({
     },
 
     /**
+     * Force delayed resolution so that we can demo async onConfirm behavior.
+     * In a real app, this action would be an action that does something async
+     * (such as make an API call), and returns a promise.
+     *
      * @returns {Promise} promise - a promise that resolves in a few seconds to imitate an async call
      */
-    resolveLater () {
+    doSomethingAsync () {
       this.get('notifications').addNotification({
         message: 'Showing progress indicator until async returns',
         type: 'success',
@@ -90,7 +98,7 @@ export default Controller.extend({
      * @param {Object} formValue - the updated value from bunsen
      */
     updateFormValue (formValue) {
-      this.set('simpleBunsenValue', formValue)
+      this.set('bunsenValue', formValue)
     },
 
     /**

--- a/tests/dummy/app/pods/demo/form-async/template.hbs
+++ b/tests/dummy/app/pods/demo/form-async/template.hbs
@@ -2,19 +2,7 @@
   {{frost-modal-outlet}}
 
   {{frost-modal-form
-    closeOnConfirm=false
-    closeAfterOnConfirmResolves=true
-    confirm=(object
-      disabled= // (false)
-      isVisible=  // (true)
-      text= // ('Confirm')
-    )
-    disableConfirmUntilOnConfirmResolves=true
-    disabledConfirm=(object
-      disabled=true
-      isVisible=  // (true)
-      text= // ('Confirm')
-    )
+    disabledConfirmText= // ('Confirm')
     form=(component 'frost-bunsen-form'
       bar= // e.g. props for 'foo'
     )
@@ -25,69 +13,56 @@
 
 {{! BEGIN-SNIPPET form-async }}
 {{frost-modal-form
-  classModifier='my-class'
-  closeOnConfirm=false
-  closeAfterOnConfirmResolves=true
+  closeOnConfirm=true
   confirm=(hash
     disabled=(not isFormValid)
   )
-  disabledConfirm=(object
-    disabled=true
-    text='Waiting...'
-  )
-  disableConfirmUntilOnConfirmResolves=true
+  disabledConfirmText='Waiting...'
   form=(component 'frost-bunsen-form'
-    bunsenModel=simpleBunsenModel
+    bunsenModel=bunsenModel
     hook='bunsen-form'
     onChange=(action 'updateFormValue')
     onValidation=(action 'updateValidity')
-    value=simpleBunsenValue
+    value=bunsenValue
   )
   hook='form-dialog'
   isVisible=isFormVisible
   subtitle='Confirm can optionally wait until onConfirm resolves'
   title='Delaying closure until a promise resolves'
   onClose=(action 'closeForm')
-  onConfirm=(action 'resolveLater')
+  onConfirm=(action 'doSomethingAsync')
 }}
 {{! END-SNIPPET }}
 
 <div class='frost-modal-demo-api'>
   <div class='frost-modal-demo-title'>
-    Optional behavior when <code>onConfirm</code> returns a promise
+    Promise-aware behavior when <code>onConfirm</code> returns a promise
   </div>
   <div class='frost-modal-demo-notes'>
     <p>
-      When <code>onConfirm</code> returns a promise, the modal can optionally be configured to
-      disable the Confirm button until the promise resolves, as well as stay open until the promise resolves.
+      When <code>onConfirm</code> returns a promise, the modal will stay open until the promise resolves.
+      It can optionally be configured to disable the Confirm button until the promise resolves.
     </p>
     <p>
-      The API for the modal is the same as normal, except for:
+      To take advantage of this feature, <code>closeOnConfirm</code> must be true
+      and your <code>onConfirm</code> action needs to return a promise.
     </p>
     <ul>
       <li><b><code>onConfirm</code></b> is a function that returns a promise</li>
-      <li><b><code>closeOnConfirm=false</code></b> to prevent early closure of the modal</li>
+      <li><b><code>closeOnConfirm=true</code></b> (default true) to enable automatic handling</li>
       <li>
-        <b><code>closeAfterConfirmResolves=true</code></b>
-        will cause the modal to automatically close once <code>onConfirm</code> resolves
+        <b><code>disableConfirmUntilOnConfirmResolves=true</code></b> (default true)
+        will disable the confirm button until <code>onConfirm</code>'s return value resolves
       </li>
       <li>
-        <b><code>disableConfirmUntilOnConfirmResolves=true</code></b>
-        will replace the Confirm button with the props in the <code>disabledConfirm</code> property
-      </li>
-      <li>
-        <b><code>disabledConfirm=(object ...)</code></b> lets you override the text to use (instead of "Confirm").
-        (You must specify both the disabled and text properties for this to work correctly.)
+        <b><code>disabledConfirmText='some string'</code></b>
+        lets you override the text to use (instead of "Confirm") when the Confirm button is disabled.
+        Default behavior is to use the <code>confirm.text</code> property.
       </li>
     </ul>
   </div>
   <div class='frost-modal-demo-title'>
     API
-  </div>
-  <div class='frost-modal-demo-notes'>
-    <p>
-      (Differences from default <code>frost-modal-form</code>)
-    </p>
   </div>
   <div class='frost-modal-demo-snippet'>
     {{code-snippet name='form-api-async.hbs'}}

--- a/tests/dummy/app/pods/demo/form-async/template.hbs
+++ b/tests/dummy/app/pods/demo/form-async/template.hbs
@@ -1,0 +1,112 @@
+{{!-- BEGIN-SNIPPET form-api-async }}
+  {{frost-modal-outlet}}
+
+  {{frost-modal-form
+    closeOnConfirm=false
+    closeAfterOnConfirmResolves=true
+    confirm=(object
+      disabled= // (false)
+      isVisible=  // (true)
+      text= // ('Confirm')
+    )
+    disableConfirmUntilOnConfirmResolves=true
+    disabledConfirm=(object
+      disabled=true
+      isVisible=  // (true)
+      text= // ('Confirm')
+    )
+    form=(component 'frost-bunsen-form'
+      bar= // e.g. props for 'foo'
+    )
+    onClose= // Required binding
+    onConfirm= // A function that returns a promise
+  }}
+{{ END-SNIPPET --}}
+
+{{! BEGIN-SNIPPET form-async }}
+{{frost-modal-form
+  classModifier='my-class'
+  closeOnConfirm=false
+  closeAfterOnConfirmResolves=true
+  confirm=(hash
+    disabled=(not isFormValid)
+  )
+  disabledConfirm=(object
+    disabled=true
+    text='Waiting...'
+  )
+  disableConfirmUntilOnConfirmResolves=true
+  form=(component 'frost-bunsen-form'
+    bunsenModel=simpleBunsenModel
+    hook='bunsen-form'
+    onChange=(action 'updateFormValue')
+    onValidation=(action 'updateValidity')
+    value=simpleBunsenValue
+  )
+  hook='form-dialog'
+  isVisible=isFormVisible
+  subtitle='Confirm can optionally wait until onConfirm resolves'
+  title='Delaying closure until a promise resolves'
+  onClose=(action 'closeForm')
+  onConfirm=(action 'resolveLater')
+}}
+{{! END-SNIPPET }}
+
+<div class='frost-modal-demo-api'>
+  <div class='frost-modal-demo-title'>
+    Optional behavior when <code>onConfirm</code> returns a promise
+  </div>
+  <div class='frost-modal-demo-notes'>
+    <p>
+      When <code>onConfirm</code> returns a promise, the modal can optionally be configured to
+      disable the Confirm button until the promise resolves, as well as stay open until the promise resolves.
+    </p>
+    <p>
+      The API for the modal is the same as normal, except for:
+    </p>
+    <ul>
+      <li><b><code>onConfirm</code></b> is a function that returns a promise</li>
+      <li><b><code>closeOnConfirm=false</code></b> to prevent early closure of the modal</li>
+      <li>
+        <b><code>closeAfterConfirmResolves=true</code></b>
+        will cause the modal to automatically close once <code>onConfirm</code> resolves
+      </li>
+      <li>
+        <b><code>disableConfirmUntilOnConfirmResolves=true</code></b>
+        will replace the Confirm button with the props in the <code>disabledConfirm</code> property
+      </li>
+      <li>
+        <b><code>disabledConfirm=(object ...)</code></b> lets you override the text to use (instead of "Confirm").
+        (You must specify both the disabled and text properties for this to work correctly.)
+      </li>
+    </ul>
+  </div>
+  <div class='frost-modal-demo-title'>
+    API
+  </div>
+  <div class='frost-modal-demo-notes'>
+    <p>
+      (Differences from default <code>frost-modal-form</code>)
+    </p>
+  </div>
+  <div class='frost-modal-demo-snippet'>
+    {{code-snippet name='form-api-async.hbs'}}
+  </div>
+</div>
+<div class='frost-modal-demo-live'>
+  <div class='frost-modal-demo-title'>
+    Live demo
+  </div>
+  <div class='frost-modal-demo-snippet'>
+    {{code-snippet name='form-async.hbs'}}
+  </div>
+  <div class='frost-modal-demo-launch'>
+    {{frost-button
+      hook='launchButton'
+      priority='primary'
+      size='medium'
+      text='Launch the modal'
+      onClick=(action 'openForm')
+    }}
+  </div>
+</div>

--- a/tests/dummy/app/pods/demo/form-async/template.hbs
+++ b/tests/dummy/app/pods/demo/form-async/template.hbs
@@ -2,7 +2,9 @@
   {{frost-modal-outlet}}
 
   {{frost-modal-form
-    disabledConfirmText= // ('Confirm')
+    confirm=(object
+      disabledText= // ('Confirm')
+    )
     form=(component 'frost-bunsen-form'
       bar= // e.g. props for 'foo'
     )
@@ -16,8 +18,8 @@
   closeOnConfirm=true
   confirm=(hash
     disabled=(not isFormValid)
+    disabledText='Waiting...'
   )
-  disabledConfirmText='Waiting...'
   form=(component 'frost-bunsen-form'
     bunsenModel=bunsenModel
     hook='bunsen-form'
@@ -55,7 +57,7 @@
         will disable the confirm button until <code>onConfirm</code>'s return value resolves
       </li>
       <li>
-        <b><code>disabledConfirmText='some string'</code></b>
+        <b><code>confirm.disabledText='some string'</code></b>
         lets you override the text to use (instead of "Confirm") when the Confirm button is disabled.
         Default behavior is to use the <code>confirm.text</code> property.
       </li>

--- a/tests/dummy/app/pods/demo/form-extras/controller.js
+++ b/tests/dummy/app/pods/demo/form-extras/controller.js
@@ -1,5 +1,5 @@
 /**
- * Demo of frost-modal-form with useful defaults
+ * Demo of frost-modal-form with extra bells and whistles
  */
 
 import Ember from 'ember'
@@ -45,7 +45,6 @@ export default Controller.extend({
     lastName: 'Lovelace'
   },
 
-  // BEGIN-SNIPPET form-actions
   actions: {
     closeForm () {
       this.setProperties({
@@ -62,13 +61,18 @@ export default Controller.extend({
       this.set('isFormVisible', true)
     },
 
-    handleConfirm () {
+    info () {
+      window.alert('OMG!')
+    },
+
+    notifyClearAndClose () {
       this.get('notifications').addNotification({
         message: JSON.stringify(this.get('bunsenValue'), null, 2),
         type: 'success',
         autoClear: true,
         clearDuration: 2000
       })
+      this.send('closeForm')
     },
 
     /**
@@ -87,5 +91,4 @@ export default Controller.extend({
       this.set('isFormValid', !validation.errors.length)
     }
   }
-  // END-SNIPPET
 })

--- a/tests/dummy/app/pods/demo/form-extras/template.hbs
+++ b/tests/dummy/app/pods/demo/form-extras/template.hbs
@@ -1,0 +1,118 @@
+{{!-- BEGIN-SNIPPET form-extras-api }}
+  {{frost-modal-outlet}}
+
+  {{! use `object` instead of `hash` to resolve issue
+      https://github.com/emberjs/ember.js/issues/14738
+      as `hash` does not have a `toString` method }}
+  {{frost-modal-form
+    buttons=(array
+      (object
+        disabled= // true
+        icon= // e.g. 'info'
+        onClick= // e.g. (action 'info')
+        pack= // e.g. 'frost'
+        priority= // ['primary', etc.]
+        text= // e.g. 'Foo'
+      )
+    )
+    cancel=(hash
+      isVisible= // (true)
+      text= // ('Cancel')
+    )
+    closeOnConfirm= // (true)
+    confirm=(hash
+      disabled= // (false)
+      isVisible=  // (true)
+      text= // ('Confirm')
+    )
+    disabledText= // (defaults to confirm.text)
+    disableConfirmUntilOnConfirmResolves= // (true)
+    footer= // e.g. 'Foo bar' or a component
+      (component 'frost-loading')
+    form=(component 'frost-bunsen-form'
+      bar= // e.g. props for 'foo'
+    )
+    isVisible= // Required binding
+    links=(array
+      (object
+        priority= // ['primary', etc.]
+        route= // e.g. 'foo.bar'
+        text= // e.g. 'Foo'
+      )
+    )
+    subtitle= // e.g. 'Foo bar'
+    targetOutlet= // ('modal')
+    title= // Required
+    onCancel= // e.g. (action 'foo')
+    onClose= // Required binding
+    onConfirm= // e.g. (action 'foo')
+  }}
+{{ END-SNIPPET --}}
+
+{{! BEGIN-SNIPPET form-extras }}
+{{frost-modal-form
+  buttons=(array
+    (object
+      icon='info'
+      onClick=(action 'info')
+      pack='frost'
+      priority='secondary'
+      text='Info'
+    )
+  )
+  classModifier='my-class'
+  closeOnConfirm=false
+  confirm=(hash
+    disabled=(not isFormValid)
+  )
+  footer='Foo bar'
+  form=(component 'frost-bunsen-form'
+    bunsenModel=bunsenModel
+    hook='bunsen-form'
+    onChange=(action 'updateFormValue')
+    onValidation=(action 'updateValidity')
+    value=bunsenValue
+  )
+  hook='form-dialog'
+  isVisible=isFormVisible
+  subtitle='Lemon squeezy'
+  title='Easy peasy'
+  onClose=(action 'closeForm')
+  onConfirm=(action 'notifyClearAndClose')
+}}
+{{! END-SNIPPET }}
+
+<div class='frost-modal-demo-api'>
+  <div class='frost-modal-demo-title'>
+    Additional <code>frost-modal-form</code> options
+  </div>
+  <div class='frost-modal-demo-notes'>
+    <p>
+      <code>frost-modal-form</code> also allows you to specify additional buttons and customized footer text.
+      You may also choose to disable <code>closeOnConfirm</code> and handle closure of the modal yourself.
+    </p>
+    <p>
+      (Differences from default <code>frost-modal-form</code> usage)
+    </p>
+  </div>
+  <div class='frost-modal-demo-snippet'>
+    {{code-snippet name='form-extras-api.hbs'}}
+  </div>
+</div>
+<div class='frost-modal-demo-live'>
+  <div class='frost-modal-demo-title'>
+    Live demo
+  </div>
+  <div class='frost-modal-demo-snippet'>
+    {{code-snippet name='form-extras.hbs'}}
+  </div>
+  <div class='frost-modal-demo-launch'>
+    {{frost-button
+      hook='launchButton'
+      priority='primary'
+      size='medium'
+      text='Launch the modal'
+      onClick=(action 'openForm')
+    }}
+  </div>
+</div>

--- a/tests/dummy/app/pods/demo/form/template.hbs
+++ b/tests/dummy/app/pods/demo/form/template.hbs
@@ -5,43 +5,16 @@
       https://github.com/emberjs/ember.js/issues/14738
       as `hash` does not have a `toString` method }}
   {{frost-modal-form
-    buttons=(array
-      (object
-        disabled= // true
-        icon= // e.g. 'info'
-        onClick= // e.g. (action 'info')
-        pack= // e.g. 'frost'
-        priority= // ['primary', etc.]
-        text= // e.g. 'Foo'
-      )
-    )
-    cancel=(hash
-      isVisible= // (true)
-      text= // ('Cancel')
-    )
-    closeOnConfirm= // (true)
-    closeAfterOnConfirmResolves= // (false)
     confirm=(hash
       disabled= // (false)
       isVisible=  // (true)
       text= // ('Confirm')
     )
-    disableConfirmUntilOnConfirmResolves= // (false)
-    footer= // e.g. 'Foo bar' or a component
-      (component 'frost-loading')
     form=(component 'frost-bunsen-form'
       bar= // e.g. props for 'foo'
     )
+    hook= // a string
     isVisible= // Required binding
-    links=(array
-      (object
-        priority= // ['primary', etc.]
-        route= // e.g. 'foo.bar'
-        text= // e.g. 'Foo'
-      )
-    )
-    subtitle= // e.g. 'Foo bar'
-    targetOutlet= // ('modal')
     title= // Required
     onCancel= // e.g. (action 'foo')
     onClose= // Required binding
@@ -51,43 +24,58 @@
 
 {{! BEGIN-SNIPPET form }}
 {{frost-modal-form
-  buttons=(array
-    (object
-      icon='info'
-      onClick=(action 'info')
-      pack='frost'
-      priority='secondary'
-      text='Info'
-    )
-  )
-  classModifier='my-class'
-  closeOnConfirm=false
+  closeOnConfirm=true
   confirm=(hash
     disabled=(not isFormValid)
   )
-  footer='Foo bar'
   form=(component 'frost-bunsen-form'
-    bunsenModel=simpleBunsenModel
-    hook='bunsen-form'
+    bunsenModel=bunsenModel
+    hook='simple-form'
     onChange=(action 'updateFormValue')
     onValidation=(action 'updateValidity')
-    value=simpleBunsenValue
+    value=bunsenValue
   )
   hook='form-dialog'
   isVisible=isFormVisible
-  subtitle='Lemon squeezy'
-  title='Easy peasy'
+  title='Basic usage'
   onClose=(action 'closeForm')
-  onConfirm=(action 'notifyClearAndClose')
+  onConfirm=(action 'handleConfirm')
 }}
 {{! END-SNIPPET }}
 
 <div class='frost-modal-demo-api'>
   <div class='frost-modal-demo-title'>
+    Basic <code>frost-modal-form</code> usage
+  </div>
+  <div class='frost-modal-demo-notes'>
+    <p>
+      The
+      <a href='https://github.com/ciena-frost/ember-frost-modal/tree/master/tests/dummy/app/pods/demo/form'
+         rel='noopener'
+         target='_blank'
+      >
+        <code>tests/dummy/app/pods/demo/form</code>
+      </a>
+      demo route demonstrates basic usage of <code>frost-modal-form</code> to present a Bunsen form.
+    </p>
+    <ul>
+      <li>The Confirm button is only enabled when the form is valid</li>
+      <li>The form value is kept by the consumer of our modal form</li>
+    </ul>
+  </div>
+  <div class='frost-modal-demo-title'>
     API
   </div>
   <div class='frost-modal-demo-snippet'>
     {{code-snippet name='form-api.hbs'}}
+  </div>
+  <div class='frost-modal-demo-notes'>
+    <p>
+      Controller actions:
+    </p>
+  </div>
+  <div class='frost-modal-demo-snippet'>
+    {{code-snippet name='form-actions.js'}}
   </div>
 </div>
 <div class='frost-modal-demo-live'>

--- a/tests/dummy/app/pods/demo/form/template.hbs
+++ b/tests/dummy/app/pods/demo/form/template.hbs
@@ -1,7 +1,9 @@
 {{!-- BEGIN-SNIPPET form-api }}
   {{frost-modal-outlet}}
 
-  {{! use `object` instead of `hash` to resolve issue https://github.com/emberjs/ember.js/issues/14738. As `hash` does not have a `toString` method }}
+  {{! use `object` instead of `hash` to resolve issue
+      https://github.com/emberjs/ember.js/issues/14738
+      as `hash` does not have a `toString` method }}
   {{frost-modal-form
     buttons=(array
       (object
@@ -18,11 +20,13 @@
       text= // ('Cancel')
     )
     closeOnConfirm= // (true)
+    closeAfterOnConfirmResolves= // (false)
     confirm=(hash
       disabled= // (false)
       isVisible=  // (true)
       text= // ('Confirm')
     )
+    disableConfirmUntilOnConfirmResolves= // (false)
     footer= // e.g. 'Foo bar' or a component
       (component 'frost-loading')
     form=(component 'frost-bunsen-form'
@@ -59,13 +63,14 @@
   classModifier='my-class'
   closeOnConfirm=false
   confirm=(hash
-    disabled=(not isSomethingReady)
+    disabled=(not isFormValid)
   )
   footer='Foo bar'
   form=(component 'frost-bunsen-form'
     bunsenModel=simpleBunsenModel
     hook='bunsen-form'
-    onChange=(action 'simpleBunsenChange')
+    onChange=(action 'updateFormValue')
+    onValidation=(action 'updateValidity')
     value=simpleBunsenValue
   )
   hook='form-dialog'

--- a/tests/dummy/app/pods/demo/info/template.hbs
+++ b/tests/dummy/app/pods/demo/info/template.hbs
@@ -1,7 +1,9 @@
 {{!-- BEGIN-SNIPPET info-api }}
   {{frost-modal-outlet}}
 
-  {{! use `object` instead of `hash` to resolve issue https://github.com/emberjs/ember.js/issues/14738. As `hash` does not have a `toString` method }}
+  {{! use `object` instead of `hash` to resolve issue
+      https://github.com/emberjs/ember.js/issues/14738
+      as `hash` does not have a `toString` method }}
   {{frost-modal-info-message
     buttons=(array
       (object

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -29,8 +29,9 @@
         {{#link-to 'demo.dialog'}}frost-modal-dialog{{/link-to}}
         <div class='frost-modal-demo-selector-title'>
           frost-modal-form
-          {{#link-to 'demo.form'}}frost-modal-form{{/link-to}}
-          {{#link-to 'demo.form-async'}}frost-modal-form with async{{/link-to}}
+          {{#link-to 'demo.form'}}Basic usage{{/link-to}}
+          {{#link-to 'demo.form-async'}}Promise-aware closeOnConfirm{{/link-to}}
+          {{#link-to 'demo.form-extras'}}Extra options{{/link-to}}
         </div>
         <div class='frost-modal-demo-selector-title'>
           Messages

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -27,7 +27,11 @@
       <div class='frost-modal-demo-selector-title'>
         Dialog components
         {{#link-to 'demo.dialog'}}frost-modal-dialog{{/link-to}}
-        {{#link-to 'demo.form'}}frost-modal-form{{/link-to}}
+        <div class='frost-modal-demo-selector-title'>
+          frost-modal-form
+          {{#link-to 'demo.form'}}frost-modal-form{{/link-to}}
+          {{#link-to 'demo.form-async'}}frost-modal-form with async{{/link-to}}
+        </div>
         <div class='frost-modal-demo-selector-title'>
           Messages
           {{#link-to 'demo.confirm'}}frost-modal-confirm-message{{/link-to}}

--- a/tests/dummy/app/pods/demo/warn/template.hbs
+++ b/tests/dummy/app/pods/demo/warn/template.hbs
@@ -1,7 +1,9 @@
 {{!-- BEGIN-SNIPPET warn-api }}
   {{frost-modal-outlet}}
 
-  {{! use `object` instead of `hash` to resolve issue https://github.com/emberjs/ember.js/issues/14738. As `hash` does not have a `toString` method }}
+  {{! use `object` instead of `hash` to resolve issue
+      https://github.com/emberjs/ember.js/issues/14738
+      as `hash` does not have a `toString` method }}
   {{frost-modal-warn-message
     buttons=(array
       (object

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -20,6 +20,7 @@ Router.map(function () {
     this.route('error')
     this.route('form')
     this.route('form-async')
+    this.route('form-extras')
     this.route('helpers')
     this.route('info')
     this.route('overflow')

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -2,7 +2,7 @@ import config from './config/environment'
 import Ember from 'ember'
 const {Router: EmberRouter} = Ember
 
-var Router = EmberRouter.extend({
+const Router = EmberRouter.extend({
   location: config.locationType,
   rootURL: config.rootURL
 })
@@ -19,6 +19,7 @@ Router.map(function () {
     this.route('dynamic-updates')
     this.route('error')
     this.route('form')
+    this.route('form-async')
     this.route('helpers')
     this.route('info')
     this.route('overflow')

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -14,7 +14,6 @@ $frost-modal-demos-shadow-color: rgba(0, 0, 0, .13);
   width: 80%;
   max-width: 400px;
   margin: auto;
-  z-index: 999;
 }
 
 .frost-modal-demo-basic-modal {

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,7 +1,7 @@
 /* eslint-env node */
 
 module.exports = function (environment) {
-  var ENV = {
+  const ENV = {
     modulePrefix: 'dummy',
     podModulePrefix: 'dummy/pods',
     environment: environment,

--- a/tests/integration/components/frost-modal-about-dialog-test.js
+++ b/tests/integration/components/frost-modal-about-dialog-test.js
@@ -29,7 +29,7 @@ describe(test.label, function () {
       copyright: Ember.String.htmlSafe('<p>Some copyright text</p>')
     })
 
-    this.render(hbs `
+    this.render(hbs`
       {{frost-modal-outlet}}
 
       {{frost-modal-about
@@ -55,8 +55,7 @@ describe(test.label, function () {
       }}
     `)
 
-    return wait()
-    .then(() => {
+    return wait().then(() => {
       expect($hook('about-dialog-modal'), 'Is modal visible').to.have.length(1)
 
       // return capture('about', done, {
@@ -73,7 +72,7 @@ describe(test.label, function () {
     })
     this.set('isModalVisible', true)
 
-    this.render(hbs `
+    this.render(hbs`
       {{frost-modal-outlet}}
 
       {{frost-modal-about
@@ -99,8 +98,7 @@ describe(test.label, function () {
       }}
     `)
 
-    return wait()
-    .then(() => {
+    return wait().then(() => {
       expect($hook('about-dialog-modal'), 'Is modal visible').to.have.length(1)
 
       // return capture('about-with-product', done, {
@@ -117,7 +115,7 @@ describe(test.label, function () {
     })
     this.set('isModalVisible', true)
 
-    this.render(hbs `
+    this.render(hbs`
       {{frost-modal-outlet}}
 
       {{frost-modal-about
@@ -157,7 +155,7 @@ describe(test.label, function () {
     })
     this.set('isModalVisible', true)
 
-    this.render(hbs `
+    this.render(hbs`
       {{frost-modal-outlet}}
 
       {{frost-modal-about

--- a/tests/integration/components/frost-modal-about-dialog-test.js
+++ b/tests/integration/components/frost-modal-about-dialog-test.js
@@ -16,7 +16,7 @@ describe(test.label, function () {
     initializeSvgUse()
   })
 
-  it('renders', function () {
+  it('should render', function () {
     this.timeout(10000)
     this.set('closeModal', () => {
       this.set('isModalVisible', false)
@@ -65,7 +65,7 @@ describe(test.label, function () {
     })
   })
 
-  it('renders with product', function () {
+  it('should render with product', function () {
     this.timeout(10000)
     this.set('closeModal', () => {
       this.set('isModalVisible', false)
@@ -108,7 +108,7 @@ describe(test.label, function () {
     })
   })
 
-  it('renders about-with-multiple-versions', function () {
+  it('should render about-with-multiple-versions', function () {
     this.timeout(10000)
     this.set('closeModal', () => {
       this.set('isModalVisible', false)
@@ -148,7 +148,7 @@ describe(test.label, function () {
       })
   })
 
-  it('renders about-with-product-and-multiple-versions', function () {
+  it('should render about-with-product-and-multiple-versions', function () {
     this.timeout(10000)
     this.set('closeModal', () => {
       this.set('isModalVisible', false)

--- a/tests/integration/components/frost-modal-about-test.js
+++ b/tests/integration/components/frost-modal-about-test.js
@@ -13,7 +13,7 @@ describe(test.label, function () {
     initialize()
   })
 
-  it('renders', function () {
+  it('should render', function () {
     this.set('actions', {
       closeModal () {
         this.set('isModalVisible', false)

--- a/tests/integration/components/frost-modal-binding-test.js
+++ b/tests/integration/components/frost-modal-binding-test.js
@@ -13,7 +13,7 @@ describe(test.label, function () {
     initialize()
   })
 
-  it('renders', function () {
+  it('should render', function () {
     this.set('isModalVisible', false)
     this.set('actions', {
       closeModal () {

--- a/tests/integration/components/frost-modal-confirm-message-test.js
+++ b/tests/integration/components/frost-modal-confirm-message-test.js
@@ -58,14 +58,14 @@ describe(test.label, function () {
       return wait()
     })
 
-    // it('renders visually as expected', function (done) {
+    // it('should render visually as expected', function (done) {
     //   return capture('confirm', done, {
     //     targetElement: this.$('.frost-modal-outlet-container.message')[0],
     //     experimentalSvgs: true
     //   })
     // })
 
-    it('renders as expected', function () {
+    it('should render as expected', function () {
       expectModalWithState({
         cancel: {
           visible: false
@@ -84,11 +84,11 @@ describe(test.label, function () {
         return wait()
       })
 
-      it('triggers the callback', function () {
+      it('should trigger the callback', function () {
         expect(props.onConfirm.called).to.equal(true)
       })
 
-      it('closes', function () {
+      it('should close', function () {
         expect($hook('confirm-dialog-modal')).to.have.length(0)
       })
     })

--- a/tests/integration/components/frost-modal-dialog-test.js
+++ b/tests/integration/components/frost-modal-dialog-test.js
@@ -7,7 +7,7 @@ const test = integration('frost-modal-dialog')
 describe(test.label, function () {
   test.setup()
 
-  it('renders', function () {
+  it('should render', function () {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.on('myAction', function(val) { ... });
     // Template block usage:

--- a/tests/integration/components/frost-modal-error-message-test.js
+++ b/tests/integration/components/frost-modal-error-message-test.js
@@ -45,14 +45,14 @@ describe(test.label, function () {
     return wait()
   })
 
-  // it('renders', function (done) {
+  // it('should render', function (done) {
   //   return capture('error-dialog', done, {
   //     targetElement: this.$('.frost-modal-outlet-container.message')[0],
   //     experimentalSvgs: true
   //   })
   // })
 
-  it('closes on cancel', function () {
+  it('should close on cancel', function () {
     $hook('error-dialog-modal-cancel').click()
 
     return wait()
@@ -68,7 +68,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('renders subtitle', function () {
+    it('should render subtitle', function () {
       const $subtitle = this.$('.frost-modal-dialog-header-subtitle')
       expect($subtitle).to.have.length(1)
       expect($subtitle.text()).to.equal('Foo bar')
@@ -81,7 +81,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('does not render subtitle DOM', function () {
+    it('should not render subtitle DOM', function () {
       expect(this.$('.frost-modal-dialog-header-subtitle')).to.have.length(0)
     })
   })
@@ -92,7 +92,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('renders footer text', function () {
+    it('should render footer text', function () {
       const $footer = this.$('.frost-modal-dialog-footer-content')
       expect($footer).to.have.length(1)
       expect($footer.text().trim()).to.equal('Foo bar')
@@ -105,7 +105,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('does not render footer text DOM', function () {
+    it('should not render footer text DOM', function () {
       expect(this.$('.frost-modal-dialog-footer-content')).to.have.length(0)
     })
   })
@@ -126,7 +126,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('renders custom buttons plus cancel and create buttons', function () {
+    it('should render custom buttons plus cancel and create buttons', function () {
       expect(this.$('.frost-modal-dialog-footer button')).to.have.length(4)
     })
   })
@@ -137,7 +137,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('only renders cancel and create buttons', function () {
+    it('should only render cancel and create buttons', function () {
       expect(this.$('.frost-modal-dialog-footer button')).to.have.length(2)
     })
   })

--- a/tests/integration/components/frost-modal-form-test.js
+++ b/tests/integration/components/frost-modal-form-test.js
@@ -23,7 +23,7 @@ describe(test.label, function () {
     initializeHook()
     this.timeout(10000)
     sandbox = sinon.sandbox.create()
-    sandbox.stub(modalDeps.Logger, 'log')
+    sandbox.stub(modalDeps.Logger, 'error')
 
     props = {
       closeOnConfirm: true,
@@ -225,7 +225,7 @@ describe(test.label, function () {
             })
 
             it('should not log an error', function () {
-              expect(modalDeps.Logger.log).to.have.callCount(0)
+              expect(modalDeps.Logger.error).to.have.callCount(0)
             })
 
             if (disableConfirmUntilOnConfirmResolves) {
@@ -252,7 +252,7 @@ describe(test.label, function () {
             })
 
             it('should log an error', function () {
-              expect(modalDeps.Logger.log).to.have.been.calledWith('failure!')
+              expect(modalDeps.Logger.error).to.have.been.calledWith('failure!')
             })
 
             if (disableConfirmUntilOnConfirmResolves) {

--- a/tests/integration/components/frost-modal-form-test.js
+++ b/tests/integration/components/frost-modal-form-test.js
@@ -1,3 +1,6 @@
+/**
+ * Integration test for frost-modal-form
+ */
 import {expect} from 'chai'
 import {$hook, initialize as initializeHook} from 'ember-hook'
 import wait from 'ember-test-helpers/wait'
@@ -241,48 +244,47 @@ describe(test.label, function () {
               })
             }
           })
-        })
 
-        // When the onConfirm promise is rejected, the error bubbles
-        describe('when the onConfirm promise rejects', function () {
-          beforeEach(function () {
-            resolver.reject('failure!')
-            return wait()
-          })
-
-          it('should log an error', function () {
-            expect(modalDeps.Logger.log).to.have.been.calledWith('failure!')
-          })
-
-          if (disableConfirmUntilOnConfirmResolves) {
-            it('should have an enabled Confirm button', function () {
-              modalUtils.expectModalConfirmButtonWithState({text: 'Confirm', disabled: false})
+          describe('when the onConfirm promise rejects', function () {
+            beforeEach(function () {
+              resolver.reject('failure!')
+              return wait()
             })
-          }
 
-          it('should not invoke `onClose`', function () {
-            expect(props.onClose).to.have.callCount(0)
+            it('should log an error', function () {
+              expect(modalDeps.Logger.log).to.have.been.calledWith('failure!')
+            })
+
+            if (disableConfirmUntilOnConfirmResolves) {
+              it('should have an enabled Confirm button', function () {
+                modalUtils.expectModalConfirmButtonWithState({text: 'Confirm', disabled: false})
+              })
+            }
+
+            it('should not invoke `onClose`', function () {
+              expect(props.onClose).to.have.callCount(0)
+            })
           })
         })
       })
     }
 
-    itShouldBePromiseAware('when disableConfirmUntilOnConfirmResolves is true (default)', {
+    itShouldBePromiseAware('when closeOnConfirm and disableConfirmUntilOnConfirmResolves are true (default)', {
       closeOnConfirm: true,
       disableConfirmUntilOnConfirmResolves: true
     })
 
-    itShouldBePromiseAware('when disableConfirmUntilOnConfirmResolves is false', {
+    itShouldBePromiseAware('when closeOnConfirm is true and disableConfirmUntilOnConfirmResolves is false', {
       closeOnConfirm: true,
       disableConfirmUntilOnConfirmResolves: false
     })
 
-    itShouldBePromiseAware('when disableConfirmUntilOnConfirmResolves is true (default)', {
+    itShouldBePromiseAware('when closeOnConfirm is false and disableConfirmUntilOnConfirmResolves is true', {
       closeOnConfirm: false,
       disableConfirmUntilOnConfirmResolves: true
     })
 
-    itShouldBePromiseAware('when disableConfirmUntilOnConfirmResolves is false', {
+    itShouldBePromiseAware('when closeOnConfirm and disableConfirmUntilOnConfirmResolves are both false', {
       closeOnConfirm: false,
       disableConfirmUntilOnConfirmResolves: false
     })
@@ -293,8 +295,15 @@ describe(test.label, function () {
       props.onConfirm.returns(42)
     })
 
-    it('should not override confirm state', function () {
-      modalUtils.expectModalConfirmButtonWithState({text: 'Confirm', disabled: false})
+    describe('when Confirm is clicked', function () {
+      beforeEach(function () {
+        $hook('form-dialog-modal-confirm').click()
+        return wait()
+      })
+
+      it('should not override confirm state', function () {
+        modalUtils.expectModalConfirmButtonWithState({text: 'Confirm', disabled: false})
+      })
     })
   })
 

--- a/tests/integration/components/frost-modal-form-test.js
+++ b/tests/integration/components/frost-modal-form-test.js
@@ -92,11 +92,11 @@ describe(test.label, function () {
     sandbox.restore()
   })
 
-  it('renders', function () {
+  it('should render', function () {
     expect($hook('form-dialog-modal')).to.have.length(1)
   })
 
-  it('closes on cancel', function () {
+  it('should close on cancel', function () {
     $hook('form-dialog-modal-cancel').click()
 
     return wait()
@@ -105,7 +105,7 @@ describe(test.label, function () {
       })
   })
 
-  it('triggers function on confirm click', function () {
+  it('should trigger function on confirm click', function () {
     $hook('form-dialog-modal-confirm').click()
 
     return wait()
@@ -114,7 +114,7 @@ describe(test.label, function () {
       })
   })
 
-  it('closes on confirm when closeOnConfirm=true', function () {
+  it('should close on confirm when closeOnConfirm=true', function () {
     $hook('form-dialog-modal-confirm').click()
 
     return wait()
@@ -165,7 +165,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('stays open', function () {
+    it('should stay open', function () {
       $hook('form-dialog-modal-confirm').click()
       expect($hook('form-dialog-modal'), 'Is modal hidden').to.have.length(1)
     })
@@ -248,7 +248,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('renders subtitle', function () {
+    it('should render subtitle', function () {
       const $subtitle = this.$('.frost-modal-dialog-header-subtitle')
       expect($subtitle).to.have.length(1)
       expect($subtitle.text()).to.equal('Foo bar')
@@ -261,7 +261,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('does not render subtitle DOM', function () {
+    it('should not render subtitle DOM', function () {
       expect(this.$('.frost-modal-dialog-header-subtitle')).to.have.length(0)
     })
   })
@@ -272,7 +272,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('renders footer text', function () {
+    it('should render footer text', function () {
       const $footer = this.$('.frost-modal-dialog-footer-content')
       expect($footer).to.have.length(1)
       expect($footer.text().trim()).to.equal('Foo bar')
@@ -285,7 +285,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('does not render footer text DOM', function () {
+    it('should not render footer text DOM', function () {
       expect(this.$('.frost-modal-dialog-footer-content')).to.have.length(0)
     })
   })
@@ -306,7 +306,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('renders custom buttons plus cancel and create buttons', function () {
+    it('should render custom buttons plus cancel and create buttons', function () {
       expect(this.$('.frost-modal-dialog-footer button')).to.have.length(4)
     })
 
@@ -352,7 +352,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('only renders cancel and create buttons', function () {
+    it('should only render cancel and create buttons', function () {
       expect(this.$('.frost-modal-dialog-footer button')).to.have.length(2)
     })
   })

--- a/tests/integration/components/frost-modal-form-test.js
+++ b/tests/integration/components/frost-modal-form-test.js
@@ -22,7 +22,10 @@ describe(test.label, function () {
 
     props = {
       closeOnConfirm: true,
-      disabledConfirmText: 'Waiting',
+      confirm: {
+        disabledText: 'Waiting',
+        text: 'Confirm'
+      },
       disableConfirmUntilOnConfirmResolves: true,
       hook: 'form-dialog',
       isFormVisible: true,
@@ -65,7 +68,6 @@ describe(test.label, function () {
         closeOnConfirm=closeOnConfirm
         closeAfterOnConfirmResolves=closeAfterOnConfirmResolves
         confirm=confirm
-        disabledConfirmText=disabledConfirmText
         disableConfirmUntilOnConfirmResolves=disableConfirmUntilOnConfirmResolves
         footer=footer
         form=(component 'frost-bunsen-form'

--- a/tests/integration/components/frost-modal-info-message-test.js
+++ b/tests/integration/components/frost-modal-info-message-test.js
@@ -34,7 +34,7 @@ describe(test.label, function () {
     return wait()
   })
 
-  // it('renders', function (done) {
+  // it('should render', function (done) {
   //   this.timeout(10000)
   //   expect($hook('info-dialog-modal'), 'Is modal visible')
   //     .to.have.length(1)
@@ -44,7 +44,7 @@ describe(test.label, function () {
   //   })
   // })
 
-  it('closes on confirm', function () {
+  it('should close on confirm', function () {
     $hook('info-dialog-modal-confirm').click()
 
     return wait()
@@ -60,7 +60,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('renders subtitle', function () {
+    it('should render subtitle', function () {
       const $subtitle = this.$('.frost-modal-dialog-header-subtitle')
       expect($subtitle).to.have.length(1)
       expect($subtitle.text()).to.equal('Foo bar')
@@ -73,7 +73,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('does not render subtitle DOM', function () {
+    it('should not render subtitle DOM', function () {
       expect(this.$('.frost-modal-dialog-header-subtitle')).to.have.length(0)
     })
   })
@@ -84,7 +84,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('renders footer text', function () {
+    it('should render footer text', function () {
       const $footer = this.$('.frost-modal-dialog-footer-content')
       expect($footer).to.have.length(1)
       expect($footer.text().trim()).to.equal('Foo bar')
@@ -97,7 +97,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('does not render footer text DOM', function () {
+    it('should not render footer text DOM', function () {
       expect(this.$('.frost-modal-dialog-footer-content')).to.have.length(0)
     })
   })
@@ -118,7 +118,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('renders custom buttons plus cancel and create buttons', function () {
+    it('should render custom buttons plus cancel and create buttons', function () {
       expect(this.$('.frost-modal-dialog-footer button')).to.have.length(4)
     })
   })
@@ -129,7 +129,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('only renders cancel and create buttons', function () {
+    it('should only render cancel and create buttons', function () {
       expect(this.$('.frost-modal-dialog-footer button')).to.have.length(2)
     })
   })

--- a/tests/integration/components/frost-modal-warn-message-test.js
+++ b/tests/integration/components/frost-modal-warn-message-test.js
@@ -45,7 +45,7 @@ describe(test.label, function () {
     return wait()
   })
 
-  // it('renders', function (done) {
+  // it('should render', function (done) {
   //   this.timeout(10000)
   //   expect($hook(props.hook), 'Is modal visible')
   //     .to.have.length(1)
@@ -56,7 +56,7 @@ describe(test.label, function () {
   //   })
   // })
 
-  it('cancel triggers callback and close', function () {
+  it('should trigger callback and close when cancel is clicked', function () {
     $hook('warning-dialog-modal-cancel').click()
 
     return wait()
@@ -75,7 +75,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('renders subtitle', function () {
+    it('should render subtitle', function () {
       const $subtitle = this.$('.frost-modal-dialog-header-subtitle')
       expect($subtitle).to.have.length(1)
       expect($subtitle.text()).to.equal('Foo bar')
@@ -88,7 +88,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('does not render subtitle DOM', function () {
+    it('should not render subtitle DOM', function () {
       expect(this.$('.frost-modal-dialog-header-subtitle')).to.have.length(0)
     })
   })
@@ -99,7 +99,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('renders footer text', function () {
+    it('should render footer text', function () {
       const $footer = this.$('.frost-modal-dialog-footer-content')
       expect($footer).to.have.length(1)
       expect($footer.text().trim()).to.equal('Foo bar')
@@ -112,7 +112,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('does not render footer text DOM', function () {
+    it('should not render footer text DOM', function () {
       expect(this.$('.frost-modal-dialog-footer-content')).to.have.length(0)
     })
   })
@@ -133,7 +133,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('renders custom buttons plus cancel and create buttons', function () {
+    it('should render custom buttons plus cancel and create buttons', function () {
       expect(this.$('.frost-modal-dialog-footer button')).to.have.length(4)
     })
   })
@@ -144,7 +144,7 @@ describe(test.label, function () {
       return wait()
     })
 
-    it('only renders cancel and create buttons', function () {
+    it('should only render cancel and create buttons', function () {
       expect(this.$('.frost-modal-dialog-footer button')).to.have.length(2)
     })
   })

--- a/tests/integration/helpers/frost-modal-blur-active-test.js
+++ b/tests/integration/helpers/frost-modal-blur-active-test.js
@@ -18,11 +18,11 @@ describe(test.label, function () {
     this.modalName = 'foo-modal'
   })
 
-  it('renders', function () {
+  it('should render', function () {
     expect(this.$('#active').text().trim()).to.equal('false')
   })
 
-  it('reflects the active state of the frost-modal service', function () {
+  it('should reflect the active state of the frost-modal service', function () {
     const active = true
 
     this.get('frost-modal').setState(this.modalName, active)
@@ -32,7 +32,7 @@ describe(test.label, function () {
     })
   })
 
-  it("doesn't blur when the noBlur property is true", function () {
+  it('should not blur when the noBlur property is true', function () {
     const active = true
     const noBlur = true
 

--- a/tests/unit/helpers/array-test.js
+++ b/tests/unit/helpers/array-test.js
@@ -4,7 +4,7 @@ import {describe, it} from 'mocha'
 
 describe('Unit / Helper / array', function () {
   // Replace this with your real tests.
-  it('works', function () {
+  it('should work', function () {
     let result = array(42)
     expect(result).not.to.equal(undefined)
   })

--- a/tests/unit/helpers/frost-modal-animation-test.js
+++ b/tests/unit/helpers/frost-modal-animation-test.js
@@ -1,6 +1,6 @@
 import {describe, it} from 'mocha'
 
 describe('Unit / Helper / frost-modal-animation', function () {
-  it('works', function () {
+  it('should work', function () {
   })
 })

--- a/tests/unit/helpers/frost-modal-outlet-animation-test.js
+++ b/tests/unit/helpers/frost-modal-outlet-animation-test.js
@@ -4,7 +4,7 @@ import {describe, it} from 'mocha'
 
 describe('Unit / Helper / frost-modal-outlet-animation', function () {
   // Replace this with your real tests.
-  it('works', function () {
+  it('should work', function () {
     // let result = frostModalOutletAnimation(42)
     // expect(result).to.be.ok
   })

--- a/tests/unit/services/frost-modal-test.js
+++ b/tests/unit/services/frost-modal-test.js
@@ -13,7 +13,7 @@ describe('Unit / Service / frost-modal', function () {
     service = this.subject()
   })
 
-  it('exists', function () {
+  it('should exist', function () {
     expect(service).not.to.equal(undefined)
   })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

### Overview

This PR adds optional flags and behavior to the `frost-modal-form` component which allows it to behave in a convenient way when `onConfirm` returns a Promise.

#### Automatically close once `onConfirm` resolves
The `closeOnConfirm` behavior has been upgraded to be Promise aware.  If `onConfirm` returns a Promise, the modal will not call `onClose` until the Promise resolves.
 
```
{{frost-modal-form
  closeOnConfirm=true
  ....
  onConfirm=(action 'somethingThatReturnsAPromise')
}}
```

> Previously, `closeOnConfirm` would ignore the return value of `onConfirm`, and invoke `onClose` immediately.  Consumers who wanted promise aware behavior have needed to disable `closeOnConfirm` and handle it themselves (which is still valid).

#### Disables the confirm button until `onConfirm` resolves

When `onConfirm` returns a Promise, we now prevent spamming of the Confirm button by disabling it until the promise resolves. setting the `closeOnConfirm` to false, and `disableConfirmUntilOnConfirmResolves` to true.

The text to be shown while disabled can be changed by overriding the `disabledConfirmText` property.

```
{{frost-modal-form
  closeOnConfirm=true
  disableConfirmUntilOnConfirmResolves=true
  // optional override of button props:
  confirm=(object
    disabledText='Waiting'
    text='Confirm'
  )
  ....
}}
```

If you do not want the Confirm button to be disabled while resolving the `onConfirm` return value, you can set `disableConfirmUntilOnConfirmResolves=false`:
```
{{frost-modal-form
  closeOnConfirm=true
  disableConfirmUntilOnConfirmResolves=false
  ....
}}
```

#### Screenshot
![ember-frost-modal-delay](https://user-images.githubusercontent.com/435544/34732273-6a1733b0-f52a-11e7-9902-0c58099ba478.gif)


 #### Demo updates

The modal form demo has been rewritten, so that there are samples of basic usage, promise-aware usage, and a demo of nearly all the bells and whistles (the original form demo route).  Each of these demos integrate the Bunsen form's validation state, as one nearly always wants the Confirm button to be disabled until the form is valid.

 # Changelog
- **Upgraded** `closeOnConfirm` to be promise-aware. If `onConfirm` returns a Promise, the modal will call `onClose` once that Promise resolves.  (Errors will leave the modal open.)
- **Added** optional `disableConfirmUntilOnConfirmResolves` flag, and the ability to specify different text for a disabled confirm button.  This behavior defaults to `true`, and is only active when handling an `onConfirm` that returns a Promise.
- **Upgraded** demo pages for `frost-modal-form` so that they show more realistic form modal usage
- **Added** support for `title` tooltips on modal buttons
- **Added** `chai-jquery`, `sinon-chai` devDependencies
- **Updated** to version `^8.1.0` of `ember-test-utils`
- **Added** eslint configuration options to allow existing test names
- **Fixed** some linting per updated linting rules
- **Fixed** demo notifications so that they show above the blur layer

  
  
  