### PR TITLE
Closes ciena-frost/ember-frost-modal#112

### DIFF
--- a/addon/components/dialogs/form.js
+++ b/addon/components/dialogs/form.js
@@ -13,7 +13,6 @@ export default FrostModalBinding.extend(PropTypesMixin, {
     cancel: PropTypes.shape({
       disabled: PropTypes.bool,
       isVisible: PropTypes.bool,
-      tabIndex: PropTypes.number,
       text: PropTypes.string,
       title: PropTypes.string
     }),

--- a/addon/components/frost-modal-binding.js
+++ b/addon/components/frost-modal-binding.js
@@ -43,7 +43,6 @@ const FrostModalBinding = Component.extend(PropTypesMixin, {
       disabled: PropTypes.bool,
       disabledText: PropTypes.string,
       isVisible: PropTypes.bool,
-      tabIndex: PropTypes.number,
       text: PropTypes.string,
       title: PropTypes.string
     }),

--- a/addon/templates/components/frost-modal-dialog.hbs
+++ b/addon/templates/components/frost-modal-dialog.hbs
@@ -80,7 +80,6 @@
     isVisible=params.cancel.isVisible
     priority='tertiary'
     size='medium'
-    tabIndex=(if (or params.cancel.tabIndex (eq params.cancel.tabIndex 0)) params.cancel.tabIndex 1)
     text=(if params.cancel.text params.cancel.text 'Cancel')
     title=(if params.cancel.title params.cancel.title)
 
@@ -97,7 +96,6 @@
       pack=button.pack
       priority=button.priority
       size='medium'
-      tabIndex=(if button.tabIndex button.tabIndex 0)
       text=button.text
       title=button.title
 
@@ -113,7 +111,6 @@
     isVisible=params.confirm.isVisible
     priority='primary'
     size='medium'
-    tabIndex=(if params.confirm.tabIndex params.confirm.tabIndex 0)
     text=(if params.confirm.text params.confirm.text 'Confirm')
     title=(if params.confirm.title params.confirm.title)
 

--- a/tests/integration/components/frost-modal-form-test.js
+++ b/tests/integration/components/frost-modal-form-test.js
@@ -128,42 +128,6 @@ describe(test.label, function () {
       })
   })
 
-  it('should have confirm button with tabIndex === 0', function () {
-    expect($hook('form-dialog-modal-confirm').prop('tabindex')).to.equal(0)
-  })
-
-  it('should have cancel button with tabIndex === 1', function () {
-    expect($hook('form-dialog-modal-cancel').prop('tabindex')).to.equal(1)
-  })
-
-  describe('when cancel is given tabIndex: 0', function () {
-    beforeEach(function () {
-      this.set('cancel', {
-        tabIndex: 0
-      })
-
-      return wait()
-    })
-
-    it('should have cancel button with tabIndex === 0', function () {
-      expect($hook('form-dialog-modal-cancel').prop('tabindex')).to.equal(0)
-    })
-  })
-
-  describe('when confirm is given tabIndex: 1', function () {
-    beforeEach(function () {
-      this.set('confirm', {
-        tabIndex: 1
-      })
-
-      return wait()
-    })
-
-    it('should have confirm button with tabIndex === 1', function () {
-      expect($hook('form-dialog-modal-confirm').prop('tabindex')).to.equal(1)
-    })
-  })
-
   describe('when closeOnConfirm is false', function () {
     beforeEach(function () {
       this.set('closeOnConfirm', false)
@@ -373,41 +337,6 @@ describe(test.label, function () {
 
     it('should render custom buttons plus cancel and create buttons', function () {
       expect(this.$('.frost-modal-dialog-footer button')).to.have.length(4)
-    })
-
-    it('should have first button with tabIndex of 0', function () {
-      expect($hook('form-dialog-modal-button-0').prop('tabindex')).to.equal(0)
-    })
-
-    it('should have second button with tabIndex of 0', function () {
-      expect($hook('form-dialog-modal-button-1').prop('tabindex')).to.equal(0)
-    })
-  })
-
-  describe('when buttons are given tabIndex', function () {
-    beforeEach(function () {
-      this.set('buttons', [
-        {
-          priority: 'secondary',
-          tabIndex: 2,
-          text: 'Foo'
-        },
-        {
-          priority: 'secondary',
-          tabIndex: 1,
-          text: 'Bar'
-        }
-      ])
-
-      return wait()
-    })
-
-    it('should have first button with tabIndex === 2', function () {
-      expect($hook('form-dialog-modal-button-0').prop('tabindex')).to.equal(2)
-    })
-
-    it('should have second button with tabIndex === 1', function () {
-      expect($hook('form-dialog-modal-button-1').prop('tabindex')).to.equal(1)
     })
   })
 


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [x] #major# - incompatible API change

# CHANGELOG
* Remove `tabIndex` support on "Cancel" and "Confirm" buttons per the discussion in #112 
