### PR TITLE
New UX for modal-form, and modal dialog headers

### DIFF
--- a/addon/components/dialogs/form.js
+++ b/addon/components/dialogs/form.js
@@ -4,7 +4,8 @@ import FrostModalBinding from '../frost-modal-binding'
 import PropTypesMixin, {PropTypes} from 'ember-prop-types'
 
 export default FrostModalBinding.extend(PropTypesMixin, {
-
+  // == Properties ============================================================
+  classNames: ['frost-modal-form'],
   // == State properties ======================================================
 
   propTypes: {

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -44,6 +44,12 @@ $frost-modal-overflow-shadow-color: rgba(0, 0, 0, .13);
   }
 }
 
+.form {
+  .frost-modal-dialog-header {
+    border-bottom: 1px $frost-color-lgrey-1 solid;
+  }
+}
+
 .frost-modal-dialog {
   display: flex;
   position: relative;
@@ -103,7 +109,7 @@ $frost-modal-overflow-shadow-color: rgba(0, 0, 0, .13);
     }
 
     &-title {
-      color: $frost-color-grey-2;
+      color: $frost-color-night-2;
       font-size: $frost-font-l;
     }
 

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -44,11 +44,7 @@ $frost-modal-overflow-shadow-color: rgba(0, 0, 0, .13);
   }
 }
 
-.frost-modal-form {
-  .frost-modal-dialog-header {
-    border-bottom: 1px $frost-color-lgrey-1 solid;
-  }
-}
+
 
 .frost-modal-dialog {
   display: flex;
@@ -57,6 +53,12 @@ $frost-modal-overflow-shadow-color: rgba(0, 0, 0, .13);
   min-width: 400px;
   min-height: 250px;
   max-height: calc(100vh - 90px); // TODO Nav height variable
+
+  &.frost-modal-form {
+    .frost-modal-dialog-header {
+      border-bottom: 1px $frost-color-lgrey-1 solid;
+    }
+  }
 
   &-content {
     margin-bottom: 70px; // TODO Footer height variable

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -44,7 +44,7 @@ $frost-modal-overflow-shadow-color: rgba(0, 0, 0, .13);
   }
 }
 
-.form {
+.frost-modal-form {
   .frost-modal-dialog-header {
     border-bottom: 1px $frost-color-lgrey-1 solid;
   }

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -98,8 +98,8 @@ $frost-modal-overflow-shadow-color: rgba(0, 0, 0, .13);
     display: flex;
     position: relative;
     align-items: center;
-    min-height: 90px;
-    padding: 20px 30px;
+    min-height: 60px;
+    padding: 20px 30px 15px;
     //border-bottom: 1px solid $frost-color-lgrey-1;
 
     & .frost-icon {

--- a/addon/templates/components/frost-modal-binding.hbs
+++ b/addon/templates/components/frost-modal-binding.hbs
@@ -4,8 +4,9 @@
     send=(hash
       animation=animation
       body=(component modal
-        classModifier=classModifier
+        class=class
         params=params
+        classNames=classNames
         hook=(concat hook '-modal')
         onCancel=(action '_onCancel')
         onClose=onClose

--- a/addon/templates/components/frost-modal-binding.hbs
+++ b/addon/templates/components/frost-modal-binding.hbs
@@ -4,6 +4,7 @@
     send=(hash
       animation=animation
       body=(component modal
+        classModifier=classModifier
         class=class
         params=params
         classNames=classNames

--- a/tests/integration/components/frost-modal-form-test.js
+++ b/tests/integration/components/frost-modal-form-test.js
@@ -100,7 +100,9 @@ describe(test.label, function () {
   it('should render', function () {
     expect($hook('form-dialog-modal')).to.have.length(1)
   })
-
+  it('should have a default class modifier', function () {
+    expect($hook('modal-outlet-modal-container')).to.have.class('frost-modal-form')
+  })
   it('should close on cancel', function () {
     $hook('form-dialog-modal-cancel').click()
 

--- a/tests/integration/components/frost-modal-form-test.js
+++ b/tests/integration/components/frost-modal-form-test.js
@@ -100,8 +100,8 @@ describe(test.label, function () {
   it('should render', function () {
     expect($hook('form-dialog-modal')).to.have.length(1)
   })
-  it('should have a default class modifier', function () {
-    expect($hook('modal-outlet-modal-container')).to.have.class('frost-modal-form')
+  it('should have frost-modal-form class', function () {
+    expect($hook('form-dialog-modal')).to.have.class('frost-modal-form')
   })
   it('should close on cancel', function () {
     $hook('form-dialog-modal-cancel').click()


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

![image](https://user-images.githubusercontent.com/9057680/37481976-74c502e4-2859-11e8-8b44-2c7260e62c0e.png)

# CHANGELOG
* Add a separator between header and body form modal-form
* Adjust `min-height` from `90px` to `60px` of all modal headers
